### PR TITLE
Fix responses not having content-type json

### DIFF
--- a/responses/responses.go
+++ b/responses/responses.go
@@ -28,6 +28,11 @@ const (
 	appJSON     = "application/json; charset=utf-8"
 )
 
+// helper function to set the Content-Type header
+func setDefaultContentType(w http.ResponseWriter) {
+	w.Header().Set(contentType, appJSON)
+}
+
 // BuildResponse builds response for RestAPI request
 func BuildResponse(status string) map[string]interface{} {
 	return map[string]interface{}{"status": status}
@@ -47,45 +52,48 @@ func BuildOkResponseWithData(dataName string, data interface{}) map[string]inter
 
 // SendResponse returns JSON response
 func SendResponse(w http.ResponseWriter, data map[string]interface{}) {
+	setDefaultContentType(w) // doesn't work if WriteHeader has been called on w first
 	json.NewEncoder(w).Encode(data)
 }
 
 // SendCreated returns response with status Created
 func SendCreated(w http.ResponseWriter, data map[string]interface{}) {
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusCreated)
 	SendResponse(w, data)
 }
 
 // SendAccepted returns response with status Accepted
 func SendAccepted(w http.ResponseWriter, data map[string]interface{}) {
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusAccepted)
 	SendResponse(w, data)
 }
 
 // SendError returns error response
 func SendError(w http.ResponseWriter, err string) {
-	w.Header().Set(contentType, appJSON)
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusBadRequest)
 	SendResponse(w, BuildResponse(err))
 }
 
 // SendForbidden returns response with status Forbidden
 func SendForbidden(w http.ResponseWriter, err string) {
-	w.Header().Set(contentType, appJSON)
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusForbidden)
 	SendResponse(w, BuildResponse(err))
 }
 
 // SendInternalServerError returns response with status Internal Server Error
 func SendInternalServerError(w http.ResponseWriter, err string) {
-	w.Header().Set(contentType, appJSON)
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusInternalServerError)
 	SendResponse(w, BuildResponse(err))
 }
 
 // SendUnauthorized returns error response for unauthorized access
 func SendUnauthorized(w http.ResponseWriter, data map[string]interface{}) {
-	w.Header().Set(contentType, appJSON)
+	setDefaultContentType(w)
 	w.WriteHeader(http.StatusUnauthorized)
 	SendResponse(w, data)
 }


### PR DESCRIPTION
Even though they actually send JSON.
Copying the message from JIRA why a nonoptimal solution is used.

@tisnik 

The best solution would be to set the Content-Type only once in the SendResponse function, since all the others call it. However, there is a [documented functionality](https://golang.org/src/net/http/server.go?s=2985:5848#L84) disallowing the modification of headers on a ResponseWriter once the WriteHeader function has been called.

With that in mind, the next best solution would be to add an extra argument to SendResponse - httpStatus int - and send the required status like that, reducing the functions to 1 line like this
```
func SendCreated(w http.ResponseWriter, data map[string]interface{}) {
	SendResponse(w, data, http.StatusCreated)
}
```
However - the insights-operator-utils is used in a lot of applications and sometimes the SendResponse is called alone which would effectively break the apps it's used in.

So, the least time-consuming solution right now is to actually set the content-type in each function.
