### PR TITLE
Goconst on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,14 @@ goerrcheck: ## Run error checks linter
 	@echo "Running error checks linter"
 	./goerrcheck.sh
 
+goconst: ## Run goconst checker
+	@echo "Running goconst checker"
+	./goconst.sh
+
 shellcheck: ## Run shellcheck
 	shellcheck *.sh
 
-style: fmt vet lint cyclo ineffassign goerrcheck shellcheck ## Run all the formatting related commands (fmt, vet, lint, cyclo)
+style: fmt vet lint cyclo ineffassign goerrcheck goconst shellcheck ## Run all the formatting related commands (fmt, vet, lint, cyclo)
 
 test: clean build ## Run the unit tests
 	@go test -coverprofile coverage.out $(shell go list ./... | grep -v tests)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It is also possible to specify CLI options for Go test. For example, if you need
 * `go vet` to report likely mistakes in source code, for example suspicious constructs, such as Printf calls whose arguments do not align with the format string.
 * `golint` as a linter for all Go sources stored in this repository
 * `gocyclo` to report all functions and methods with too high cyclomatic complexity. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each 'if', 'for', 'case', '&&' or '||' Go Report Card warns on functions with cyclomatic complexity > 9
+* `goconst` to find repeated strings that could be replaced by a constant
 * `ineffassign` to detect and print all ineffectual assignments in Go code
 * `errcheck` for checking for all unchecked errors in go programs
 * `shellcheck` to perform static analysis for all shell scripts used in this repository

--- a/goconst.sh
+++ b/goconst.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+go get github.com/jgautheron/goconst/cmd/goconst
+goconst ./...

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 go get github.com/fzipp/gocyclo
 gocyclo -over 9 -avg .

--- a/ineffassign.sh
+++ b/ineffassign.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 go get github.com/gordonklaus/ineffassign
 ineffassign .


### PR DESCRIPTION
# Description

Setup `goconst` tool on CI + updating documentation a bit

Fixes #31 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps
It's done on CI or you can run the new `goconst.sh` script
