### PR TITLE
Incorporate gosec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,22 +22,26 @@ ineffassign: ## Run ineffassign checker
 	@echo "Running ineffassign checker"
 	./ineffassign.sh
 
-goerrcheck: ## Run error checks linter
-	@echo "Running error checks linter"
+shellcheck: ## Run shellcheck
+	shellcheck *.sh
+
+errcheck: ## Run errcheck
+	@echo "Running errcheck"
 	./goerrcheck.sh
 
 goconst: ## Run goconst checker
 	@echo "Running goconst checker"
 	./goconst.sh
 
-shellcheck: ## Run shellcheck
-	shellcheck *.sh
+gosec: ## Run gosec checker
+	@echo "Running gosec checker"
+	./gosec.sh
 
 abcgo: ## Run ABC metrics checker
 	@echo "Run ABC metrics checker"
 	./abcgo.sh
 
-style: fmt vet lint cyclo ineffassign goerrcheck goconst shellcheck abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo)
+style: fmt vet lint cyclo shellcheck errcheck goconst gosec ineffassign abcgo ## Run all the formatting related commands (fmt, vet, lint, cyclo) + check shell scripts
 
 test: clean build ## Run the unit tests
 	@go test -coverprofile coverage.out $(shell go list ./... | grep -v tests)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ It is also possible to specify CLI options for Go test. For example, if you need
 * `golint` as a linter for all Go sources stored in this repository
 * `gocyclo` to report all functions and methods with too high cyclomatic complexity. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each 'if', 'for', 'case', '&&' or '||' Go Report Card warns on functions with cyclomatic complexity > 9
 * `goconst` to find repeated strings that could be replaced by a constant
+* `gosec` to inspect source code for security problems by scanning the Go AST
 * `ineffassign` to detect and print all ineffectual assignments in Go code
 * `errcheck` for checking for all unchecked errors in go programs
 * `shellcheck` to perform static analysis for all shell scripts used in this repository

--- a/gosec.sh
+++ b/gosec.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+cd "$(dirname "$0")" || exit
+
+echo -e "${BLUE}Security issues detection${NC}"
+
+go get github.com/securego/gosec/cmd/gosec
+
+if ! gosec ./...
+then
+    echo -e "${RED}Potential security issues detected!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}No potential security issues has been detected${NC}"
+    exit 0
+fi


### PR DESCRIPTION
# Description

Incorporate `gosec` security issues checker into CI.

Fixes #40 

## Type of change

- Tests on CI
- Documentation update

## Testing steps
Run `make style`
