### PR TITLE
add Internal field to RuleWithContent and RuleContentResponse

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -76,6 +76,7 @@ type RuleContentResponse struct {
 	Tags         []string    `json:"tags"`
 	UserVote     UserVote    `json:"user_vote"`
 	Disabled     bool        `json:"disabled"`
+	Internal     bool        `json:"internal"`
 }
 
 // DisabledRuleResponse represents a single disabled rule displaying only identifying information
@@ -128,6 +129,7 @@ type RuleWithContent struct {
 	RiskOfChange int       `json:"risk_of_change"`
 	PublishDate  time.Time `json:"publish_date"`
 	Active       bool      `json:"active"`
+	Internal     bool      `json:"internal"`
 	Generic      string    `json:"generic"`
 	Tags         []string  `json:"tags"`
 }


### PR DESCRIPTION
# Description
add Internal field to RuleWithContent and RuleContentResponse, I got my types.go confused a bit locally
Necessary for https://github.com/RedHatInsights/insights-results-smart-proxy/pull/85

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


## Testing steps
`make test`
