### PR TITLE
Cloudwatch logging as a library

### DIFF
--- a/docs/packages/logger/configuration.html
+++ b/docs/packages/logger/configuration.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2020 Red Hat, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+<head>
+<title>configuration.go</title>
+<meta charset="utf-8"/>
+<style type="text/css">body {
+    background: rgb(225, 225, 225);
+    margin: 0px;
+    padding: 0px;
+}
+
+#docgo p {
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo div {
+    display: inline;
+}
+
+#docgo #background {
+    position: fixed;
+    top: 0; left: 525px; right: 0; bottom: 0;
+    background: rgb(47, 47, 47);
+    border-left: 1px solid #e5e5ee;
+    z-index: -1;
+}
+
+#docgo .keyword {
+    color: rgb(250, 200, 100);
+}
+
+#docgo .literal {
+    color: rgb(140, 190, 100);
+}
+
+#docgo .ident {
+    color: white;
+}
+
+#docgo .operator {
+    color: white;
+}
+
+#docgo .comment {
+}
+
+#docgo h1, h2, h3, h4, h5 {
+    text-align: left;
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo h1 {
+    margin-top: 40px;
+}
+
+#docgo .doc {
+    vertical-align: top;
+    font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, FreeSerif, serif;
+    font-size: 15px;
+    line-height: 22px;
+    color: black;
+    min-width: 450px;
+    max-width: 450px;
+    padding-top: 10px;
+    padding-right: 25px;
+    padding-bottom: 1px;
+    padding-left: 50px;
+    overflow-x: hidden;
+}
+
+#docgo .code {
+    min-width: 650px;
+    max-width: 650px;
+    padding-left: 25px;
+    padding-right: 15px;
+    border-left: 1px;
+    overflow-x: hidden;
+    vertical-align: top;
+}
+
+#docgo .code pre code  {
+    font-size: 12px;
+    line-height: 18px;
+    font-family: Menlo, Monaco, Consolas, "Lucida Console", monospace;
+    color: rgb(120, 120, 120);
+}
+</style>
+</head>
+<body>
+<div id="docgo">
+  <div id="background"></div>
+  <table>
+    <thead><tr><th class="doc"><h1>configuration.go</h1></th><th class="code"></th></tr></thead>
+    <tbody>
+      
+      <tr class="section">
+	<td class="doc"></td>
+	<td class="code"><pre><code><div class="comment">/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/</div>
+
+<div class="keyword">package</div> <div class="ident">logger</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>LoggingConfiguration represents configuration for logging in general</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">LoggingConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Debug enables pretty colored logging</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">Debug</div> <div class="ident">bool</div> <div class="literal">`mapstructure:&#34;debug&#34; toml:&#34;debug&#34;`</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>LogLevel sets logging level to show. Possible values are:
+&quot;debug&quot;
+&quot;info&quot;
+&quot;warn&quot;, &quot;warning&quot;
+&quot;error&quot;
+&quot;fatal&quot;</p>
+
+<p>logging level won't be changed if value is not one of listed above</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">LogLevel</div> <div class="ident">string</div> <div class="literal">`mapstructure:&#34;log_level&#34; toml:&#34;log_level&#34;`</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>LoggingToCloudWatchEnabled enables logging to CloudWatch
+(configuration for CloudWatch is in CloudWatchConfiguration)</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">LoggingToCloudWatchEnabled</div> <div class="ident">bool</div> <div class="literal">`mapstructure:&#34;logging_to_cloud_watch_enabled&#34; toml:&#34;logging_to_cloud_watch_enabled&#34;`</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>CloudWatchConfiguration represents configuration of CloudWatch logger</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">CloudWatchConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
+	<div class="ident">AWSAccessID</div>             <div class="ident">string</div> <div class="literal">`mapstructure:&#34;aws_access_id&#34; toml:&#34;aws_access_id&#34;`</div><div class="operator"></div>
+	<div class="ident">AWSSecretKey</div>            <div class="ident">string</div> <div class="literal">`mapstructure:&#34;aws_secret_key&#34; toml:&#34;aws_secret_key&#34;`</div><div class="operator"></div>
+	<div class="ident">AWSSessionToken</div>         <div class="ident">string</div> <div class="literal">`mapstructure:&#34;aws_session_token&#34; toml:&#34;aws_session_token&#34;`</div><div class="operator"></div>
+	<div class="ident">AWSRegion</div>               <div class="ident">string</div> <div class="literal">`mapstructure:&#34;aws_region&#34; toml:&#34;aws_region&#34;`</div><div class="operator"></div>
+	<div class="ident">LogGroup</div>                <div class="ident">string</div> <div class="literal">`mapstructure:&#34;log_group&#34; toml:&#34;log_group&#34;`</div><div class="operator"></div>
+	<div class="ident">StreamName</div>              <div class="ident">string</div> <div class="literal">`mapstructure:&#34;stream_name&#34; toml:&#34;stream_name&#34;`</div><div class="operator"></div>
+	<div class="ident">CreateStreamIfNotExists</div> <div class="ident">bool</div>   <div class="literal">`mapstructure:&#34;create_stream_if_not_exists&#34; toml:&#34;create_stream_if_not_exists&#34;`</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>enable debug logs for debugging aws client itself</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">Debug</div> <div class="ident">bool</div> <div class="literal">`mapstructure:&#34;debug&#34; toml:&#34;debug&#34;`</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/docs/packages/logger/logger.html
+++ b/docs/packages/logger/logger.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2020 Red Hat, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+<head>
+<title>logger.go</title>
+<meta charset="utf-8"/>
+<style type="text/css">body {
+    background: rgb(225, 225, 225);
+    margin: 0px;
+    padding: 0px;
+}
+
+#docgo p {
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo div {
+    display: inline;
+}
+
+#docgo #background {
+    position: fixed;
+    top: 0; left: 525px; right: 0; bottom: 0;
+    background: rgb(47, 47, 47);
+    border-left: 1px solid #e5e5ee;
+    z-index: -1;
+}
+
+#docgo .keyword {
+    color: rgb(250, 200, 100);
+}
+
+#docgo .literal {
+    color: rgb(140, 190, 100);
+}
+
+#docgo .ident {
+    color: white;
+}
+
+#docgo .operator {
+    color: white;
+}
+
+#docgo .comment {
+}
+
+#docgo h1, h2, h3, h4, h5 {
+    text-align: left;
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo h1 {
+    margin-top: 40px;
+}
+
+#docgo .doc {
+    vertical-align: top;
+    font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, FreeSerif, serif;
+    font-size: 15px;
+    line-height: 22px;
+    color: black;
+    min-width: 450px;
+    max-width: 450px;
+    padding-top: 10px;
+    padding-right: 25px;
+    padding-bottom: 1px;
+    padding-left: 50px;
+    overflow-x: hidden;
+}
+
+#docgo .code {
+    min-width: 650px;
+    max-width: 650px;
+    padding-left: 25px;
+    padding-right: 15px;
+    border-left: 1px;
+    overflow-x: hidden;
+    vertical-align: top;
+}
+
+#docgo .code pre code  {
+    font-size: 12px;
+    line-height: 18px;
+    font-family: Menlo, Monaco, Consolas, "Lucida Console", monospace;
+    color: rgb(120, 120, 120);
+}
+</style>
+</head>
+<body>
+<div id="docgo">
+  <div id="background"></div>
+  <table>
+    <thead><tr><th class="doc"><h1>logger.go</h1></th><th class="code"></th></tr></thead>
+    <tbody>
+      
+      <tr class="section">
+	<td class="doc"></td>
+	<td class="code"><pre><code><div class="comment">/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &#34;AS IS&#34; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/</div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Package logger contains the configuration structures needed to configure
+the access to CloudWatch server to sending the log messages there.</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">logger</div><div class="operator"></div>
+
+<div class="keyword">import</div> <div class="operator">(</div>
+	<div class="literal">&#34;encoding/json&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;fmt&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;io&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;os&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;strings&#34;</div><div class="operator"></div>
+
+	<div class="literal">&#34;github.com/RedHatInsights/cloudwatch&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/Shopify/sarama&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/aws/aws-sdk-go/aws&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/aws/aws-sdk-go/aws/credentials&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/aws/aws-sdk-go/aws/session&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/aws/aws-sdk-go/service/cloudwatchlogs&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/rs/zerolog&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/rs/zerolog/log&#34;</div><div class="operator"></div>
+<div class="operator">)</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>WorkaroundForRHIOPS729 keeps only those fields that are currently getting their way to Kibana
+TODO: delete when RHIOPS-729 is fixed</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">WorkaroundForRHIOPS729</div> <div class="keyword">struct</div> <div class="operator">{</div>
+	<div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="operator">(</div><div class="ident">writer</div> <div class="ident">WorkaroundForRHIOPS729</div><div class="operator">)</div> <div class="ident">Write</div><div class="operator">(</div><div class="ident">bytes</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">byte</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">int</div><div class="operator">,</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">var</div> <div class="ident">obj</div> <div class="keyword">map</div><div class="operator">[</div><div class="ident">string</div><div class="operator">]</div><div class="keyword">interface</div><div class="operator">{</div><div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">json</div><div class="operator">.</div><div class="ident">Unmarshal</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">obj</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>it's not JSON object, so we don't do anything</p>
+</td>
+	<td class="code"><pre><code>		<div class="keyword">return</div> <div class="ident">writer</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">.</div><div class="ident">Write</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>lowercase the keys</p>
+</td>
+	<td class="code"><pre><code>	<div class="keyword">for</div> <div class="ident">key</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">obj</div> <div class="operator">{</div>
+		<div class="ident">val</div> <div class="operator">:=</div> <div class="ident">obj</div><div class="operator">[</div><div class="ident">key</div><div class="operator">]</div><div class="operator"></div>
+		<div class="ident">delete</div><div class="operator">(</div><div class="ident">obj</div><div class="operator">,</div> <div class="ident">key</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">obj</div><div class="operator">[</div><div class="ident">strings</div><div class="operator">.</div><div class="ident">ToUpper</div><div class="operator">(</div><div class="ident">key</div><div class="operator">)</div><div class="operator">]</div> <div class="operator">=</div> <div class="ident">val</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">resultBytes</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">json</div><div class="operator">.</div><div class="ident">Marshal</div><div class="operator">(</div><div class="ident">obj</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+		<div class="keyword">return</div> <div class="literal">0</div><div class="operator">,</div> <div class="ident">err</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">written</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">writer</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">.</div><div class="ident">Write</div><div class="operator">(</div><div class="ident">resultBytes</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+		<div class="keyword">return</div> <div class="ident">written</div><div class="operator">,</div> <div class="ident">err</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">written</div> <div class="operator">&lt;</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">resultBytes</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">return</div> <div class="ident">written</div><div class="operator">,</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Errorf</div><div class="operator">(</div><div class="literal">&#34;too few bytes were written&#34;</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">return</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">nil</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>AWSCloudWatchEndpoint allows you to mock cloudwatch client by redirecting requests to a local proxy</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">var</div> <div class="ident">AWSCloudWatchEndpoint</div> <div class="ident">string</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>InitZerolog initializes zerolog with provided configs to use proper stdout and/or CloudWatch logging</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">InitZerolog</div><div class="operator">(</div>
+	<div class="ident">loggingConf</div> <div class="ident">LoggingConfiguration</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div> <div class="ident">CloudWatchConfiguration</div><div class="operator">,</div> <div class="ident">additionalWriters</div> <div class="operator">...</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">,</div>
+<div class="operator">)</div> <div class="ident">error</div> <div class="operator">{</div>
+	<div class="ident">setGlobalLogLevel</div><div class="operator">(</div><div class="ident">loggingConf</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">var</div> <div class="ident">writers</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
+
+	<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">additionalWriters</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">Debug</div> <div class="operator">{</div>
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>nice colored output</p>
+</td>
+	<td class="code"><pre><code>		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ConsoleWriter</div><div class="operator">{</div><div class="ident">Out</div><div class="operator">:</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Stdout</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Stdout</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ReplaceAll</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="literal">&#34;$HOSTNAME&#34;</div><div class="operator">,</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Getenv</div><div class="operator">(</div><div class="literal">&#34;HOSTNAME&#34;</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">LoggingToCloudWatchEnabled</div> <div class="operator">{</div>
+		<div class="ident">awsLogLevel</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogOff</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">Debug</div> <div class="operator">{</div>
+			<div class="ident">awsLogLevel</div> <div class="operator">=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
+				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
+				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithHTTPBody</div> <div class="operator">|</div>
+				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithEventStreamBody</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">awsConf</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">NewConfig</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div>
+			<div class="ident">WithCredentials</div><div class="operator">(</div><div class="ident">credentials</div><div class="operator">.</div><div class="ident">NewStaticCredentials</div><div class="operator">(</div>
+				<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSAccessID</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSSecretKey</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSSessionToken</div><div class="operator">,</div>
+			<div class="operator">)</div><div class="operator">)</div><div class="operator">.</div>
+			<div class="ident">WithRegion</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSRegion</div><div class="operator">)</div><div class="operator">.</div>
+			<div class="ident">WithLogLevel</div><div class="operator">(</div><div class="ident">awsLogLevel</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">if</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div> <div class="operator">&gt;</div> <div class="literal">0</div> <div class="operator">{</div>
+			<div class="ident">awsConf</div> <div class="operator">=</div> <div class="ident">awsConf</div><div class="operator">.</div><div class="ident">WithEndpoint</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">cloudWatchSession</div> <div class="operator">:=</div> <div class="ident">session</div><div class="operator">.</div><div class="ident">Must</div><div class="operator">(</div><div class="ident">session</div><div class="operator">.</div><div class="ident">NewSession</div><div class="operator">(</div><div class="ident">awsConf</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">CloudWatchClient</div> <div class="operator">:=</div> <div class="ident">cloudwatchlogs</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">cloudWatchSession</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">var</div> <div class="ident">cloudWatchWriter</div> <div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">CreateStreamIfNotExists</div> <div class="operator">{</div>
+			<div class="ident">group</div> <div class="operator">:=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewGroup</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">)</div><div class="operator"></div>
+
+			<div class="keyword">var</div> <div class="ident">err</div> <div class="ident">error</div><div class="operator"></div>
+			<div class="ident">cloudWatchWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">=</div> <div class="ident">group</div><div class="operator">.</div><div class="ident">Create</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">)</div><div class="operator"></div>
+			<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+				<div class="keyword">return</div> <div class="ident">err</div><div class="operator"></div>
+			<div class="operator">}</div><div class="operator"></div>
+		<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+			<div class="ident">cloudWatchWriter</div> <div class="operator">=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewWriter</div><div class="operator">(</div>
+				<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">,</div>
+			<div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">WorkaroundForRHIOPS729</div><div class="operator">{</div><div class="ident">Writer</div><div class="operator">:</div> <div class="ident">cloudWatchWriter</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">logsWriter</div> <div class="operator">:=</div> <div class="ident">io</div><div class="operator">.</div><div class="ident">MultiWriter</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="ident">log</div><div class="operator">.</div><div class="ident">Logger</div> <div class="operator">=</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">logsWriter</div><div class="operator">)</div><div class="operator">.</div><div class="ident">With</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Timestamp</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>zerolog doesn't implement Println required by sarama</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">sarama</div><div class="operator">.</div><div class="ident">Logger</div> <div class="operator">=</div> <div class="operator">&amp;</div><div class="ident">SaramaZerologger</div><div class="operator">{</div><div class="ident">zerologger</div><div class="operator">:</div> <div class="ident">log</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">return</div> <div class="ident">nil</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">setGlobalLogLevel</div><div class="operator">(</div><div class="ident">configuration</div> <div class="ident">LoggingConfiguration</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">logLevel</div> <div class="operator">:=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ToLower</div><div class="operator">(</div><div class="ident">strings</div><div class="operator">.</div><div class="ident">TrimSpace</div><div class="operator">(</div><div class="ident">configuration</div><div class="operator">.</div><div class="ident">LogLevel</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">switch</div> <div class="ident">logLevel</div> <div class="operator">{</div>
+	<div class="keyword">case</div> <div class="literal">&#34;debug&#34;</div><div class="operator">:</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">DebugLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="literal">&#34;info&#34;</div><div class="operator">:</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">InfoLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="literal">&#34;warn&#34;</div><div class="operator">,</div> <div class="literal">&#34;warning&#34;</div><div class="operator">:</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">WarnLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="literal">&#34;error&#34;</div><div class="operator">:</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ErrorLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">case</div> <div class="literal">&#34;fatal&#34;</div><div class="operator">:</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">FatalLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">const</div> <div class="ident">kafkaErrorPrefix</div> <div class="operator">=</div> <div class="literal">&#34;kafka: error&#34;</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>SaramaZerologger is a wrapper to make sarama log to zerolog
+those logs can be filtered by key &quot;package&quot; with value &quot;sarama&quot;</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">SaramaZerologger</div> <div class="keyword">struct</div><div class="operator">{</div> <div class="ident">zerologger</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">Logger</div> <div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Print wraps print method</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">logger</div> <div class="operator">*</div><div class="ident">SaramaZerologger</div><div class="operator">)</div> <div class="ident">Print</div><div class="operator">(</div><div class="ident">params</div> <div class="operator">...</div><div class="keyword">interface</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">var</div> <div class="ident">messages</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">string</div><div class="operator"></div>
+	<div class="keyword">for</div> <div class="ident">_</div><div class="operator">,</div> <div class="ident">item</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">params</div> <div class="operator">{</div>
+		<div class="ident">messages</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">messages</div><div class="operator">,</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Sprint</div><div class="operator">(</div><div class="ident">item</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">logger</div><div class="operator">.</div><div class="ident">logMessage</div><div class="operator">(</div><div class="literal">&#34;%v&#34;</div><div class="operator">,</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">Join</div><div class="operator">(</div><div class="ident">messages</div><div class="operator">,</div> <div class="literal">&#34; &#34;</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Printf wraps printf method</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">logger</div> <div class="operator">*</div><div class="ident">SaramaZerologger</div><div class="operator">)</div> <div class="ident">Printf</div><div class="operator">(</div><div class="ident">format</div> <div class="ident">string</div><div class="operator">,</div> <div class="ident">params</div> <div class="operator">...</div><div class="keyword">interface</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">logger</div><div class="operator">.</div><div class="ident">logMessage</div><div class="operator">(</div><div class="ident">format</div><div class="operator">,</div> <div class="ident">params</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>Println wraps println method</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">logger</div> <div class="operator">*</div><div class="ident">SaramaZerologger</div><div class="operator">)</div> <div class="ident">Println</div><div class="operator">(</div><div class="ident">v</div> <div class="operator">...</div><div class="keyword">interface</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">logger</div><div class="operator">.</div><div class="ident">Print</div><div class="operator">(</div><div class="ident">v</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="operator">(</div><div class="ident">logger</div> <div class="operator">*</div><div class="ident">SaramaZerologger</div><div class="operator">)</div> <div class="ident">logMessage</div><div class="operator">(</div><div class="ident">format</div> <div class="ident">string</div><div class="operator">,</div> <div class="ident">params</div> <div class="operator">...</div><div class="keyword">interface</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">var</div> <div class="ident">event</div> <div class="operator">*</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">Event</div><div class="operator"></div>
+	<div class="ident">messageStr</div> <div class="operator">:=</div> <div class="ident">fmt</div><div class="operator">.</div><div class="ident">Sprintf</div><div class="operator">(</div><div class="ident">format</div><div class="operator">,</div> <div class="ident">params</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">HasPrefix</div><div class="operator">(</div><div class="ident">messageStr</div><div class="operator">,</div> <div class="ident">kafkaErrorPrefix</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="ident">event</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">zerologger</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+		<div class="ident">event</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">zerologger</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">event</div> <div class="operator">=</div> <div class="ident">event</div><div class="operator">.</div><div class="ident">Str</div><div class="operator">(</div><div class="literal">&#34;package&#34;</div><div class="operator">,</div> <div class="literal">&#34;sarama&#34;</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">event</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="ident">messageStr</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/docs/packages/logger/logger_test.html
+++ b/docs/packages/logger/logger_test.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2020 Red Hat, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<html>
+<head>
+<title>logger_test.go</title>
+<meta charset="utf-8"/>
+<style type="text/css">body {
+    background: rgb(225, 225, 225);
+    margin: 0px;
+    padding: 0px;
+}
+
+#docgo p {
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo div {
+    display: inline;
+}
+
+#docgo #background {
+    position: fixed;
+    top: 0; left: 525px; right: 0; bottom: 0;
+    background: rgb(47, 47, 47);
+    border-left: 1px solid #e5e5ee;
+    z-index: -1;
+}
+
+#docgo .keyword {
+    color: rgb(250, 200, 100);
+}
+
+#docgo .literal {
+    color: rgb(140, 190, 100);
+}
+
+#docgo .ident {
+    color: white;
+}
+
+#docgo .operator {
+    color: white;
+}
+
+#docgo .comment {
+}
+
+#docgo h1, h2, h3, h4, h5 {
+    text-align: left;
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 15px;
+    margin-left: 0px;
+}
+
+#docgo h1 {
+    margin-top: 40px;
+}
+
+#docgo .doc {
+    vertical-align: top;
+    font-family: 'Palatino Linotype', 'Book Antiqua', Palatino, FreeSerif, serif;
+    font-size: 15px;
+    line-height: 22px;
+    color: black;
+    min-width: 450px;
+    max-width: 450px;
+    padding-top: 10px;
+    padding-right: 25px;
+    padding-bottom: 1px;
+    padding-left: 50px;
+    overflow-x: hidden;
+}
+
+#docgo .code {
+    min-width: 650px;
+    max-width: 650px;
+    padding-left: 25px;
+    padding-right: 15px;
+    border-left: 1px;
+    overflow-x: hidden;
+    vertical-align: top;
+}
+
+#docgo .code pre code  {
+    font-size: 12px;
+    line-height: 18px;
+    font-family: Menlo, Monaco, Consolas, "Lucida Console", monospace;
+    color: rgb(120, 120, 120);
+}
+</style>
+</head>
+<body>
+<div id="docgo">
+  <div id="background"></div>
+  <table>
+    <thead><tr><th class="doc"><h1>logger_test.go</h1></th><th class="code"></th></tr></thead>
+    <tbody>
+      
+      <tr class="section">
+	<td class="doc"><p>Copyright 2020 Red Hat, Inc</p>
+
+<p>Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at</p>
+
+<pre><code> http://www.apache.org/licenses/LICENSE-2.0
+</code></pre>
+
+<p>Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">logger_test</div><div class="operator"></div>
+
+<div class="keyword">import</div> <div class="operator">(</div>
+	<div class="literal">&#34;bytes&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;net/http&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;strings&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;testing&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;time&#34;</div><div class="operator"></div>
+
+	<div class="literal">&#34;github.com/RedHatInsights/insights-operator-utils/logger&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/RedHatInsights/insights-operator-utils/tests/helpers&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/Shopify/sarama&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/rs/zerolog&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/rs/zerolog/log&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/stretchr/testify/assert&#34;</div><div class="operator"></div>
+<div class="operator">)</div><div class="operator"></div>
+
+<div class="keyword">const</div> <div class="operator">(</div>
+	<div class="ident">testTimeout</div> <div class="operator">=</div> <div class="literal">10</div> <div class="operator">*</div> <div class="ident">time</div><div class="operator">.</div><div class="ident">Second</div><div class="operator"></div>
+<div class="operator">)</div><div class="operator"></div>
+
+<div class="keyword">var</div> <div class="operator">(</div>
+	<div class="ident">cloudWatchConf</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div>
+		<div class="ident">AWSAccessID</div><div class="operator">:</div>             <div class="literal">&#34;access ID&#34;</div><div class="operator">,</div>
+		<div class="ident">AWSSecretKey</div><div class="operator">:</div>            <div class="literal">&#34;secret&#34;</div><div class="operator">,</div>
+		<div class="ident">AWSSessionToken</div><div class="operator">:</div>         <div class="literal">&#34;sess token&#34;</div><div class="operator">,</div>
+		<div class="ident">AWSRegion</div><div class="operator">:</div>               <div class="literal">&#34;aws region&#34;</div><div class="operator">,</div>
+		<div class="ident">LogGroup</div><div class="operator">:</div>                <div class="literal">&#34;log group&#34;</div><div class="operator">,</div>
+		<div class="ident">StreamName</div><div class="operator">:</div>              <div class="literal">&#34;stream name&#34;</div><div class="operator">,</div>
+		<div class="ident">CreateStreamIfNotExists</div><div class="operator">:</div> <div class="ident">true</div><div class="operator">,</div>
+		<div class="ident">Debug</div><div class="operator">:</div>                   <div class="ident">false</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator"></div>
+	<div class="ident">describeLogStreamsEvent</div> <div class="operator">=</div> <div class="ident">CloudWatchExpect</div><div class="operator">{</div>
+		<div class="ident">http</div><div class="operator">.</div><div class="ident">MethodPost</div><div class="operator">,</div>
+		<div class="literal">&#34;Logs_20140328.DescribeLogStreams&#34;</div><div class="operator">,</div>
+		<div class="literal">`{
+					&#34;descending&#34;: false,
+					&#34;logGroupName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;logStreamNamePrefix&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;orderBy&#34;: &#34;LogStreamName&#34;
+				}`</div><div class="operator">,</div>
+		<div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+		<div class="literal">`{
+					&#34;logStreams&#34;: [
+						{
+							&#34;arn&#34;: &#34;arn:aws:logs:`</div> <div class="operator">&#43;</div>
+			<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSRegion</div> <div class="operator">&#43;</div> <div class="literal">`:012345678910:log-group:`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div> <div class="operator">&#43;</div>
+			<div class="literal">`:log-stream:`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+							&#34;creationTime&#34;: 1,
+							&#34;firstEventTimestamp&#34;: 2,
+							&#34;lastEventTimestamp&#34;: 3,
+							&#34;lastIngestionTime&#34;: 4,
+							&#34;logStreamName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+							&#34;storedBytes&#34;: 100,
+							&#34;uploadSequenceToken&#34;: &#34;1&#34;
+						}
+					],
+					&#34;nextToken&#34;: &#34;token1&#34;
+				}`</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">)</div><div class="operator"></div>
+
+<div class="keyword">type</div> <div class="ident">CloudWatchExpect</div> <div class="keyword">struct</div> <div class="operator">{</div>
+	<div class="ident">ExpectedMethod</div>   <div class="ident">string</div><div class="operator"></div>
+	<div class="ident">ExpectedTarget</div>   <div class="ident">string</div><div class="operator"></div>
+	<div class="ident">ExpectedBody</div>     <div class="ident">string</div><div class="operator"></div>
+	<div class="ident">ResultStatusCode</div> <div class="ident">int</div><div class="operator"></div>
+	<div class="ident">ResultBody</div>       <div class="ident">string</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestSaramaZerologger</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">const</div> <div class="ident">expectedStrInfoLevel</div> <div class="operator">=</div> <div class="literal">&#34;some random message&#34;</div><div class="operator"></div>
+	<div class="keyword">const</div> <div class="ident">expectedErrStrErrorLevel</div> <div class="operator">=</div> <div class="literal">&#34;kafka: error test error&#34;</div><div class="operator"></div>
+
+	<div class="ident">buf</div> <div class="operator">:=</div> <div class="ident">new</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">.</div><div class="ident">Buffer</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
+			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
+			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">buf</div><div class="operator">)</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator"></div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="ident">t</div><div class="operator">.</div><div class="ident">Run</div><div class="operator">(</div><div class="literal">&#34;InfoLevel&#34;</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="ident">buf</div><div class="operator">.</div><div class="ident">Reset</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">sarama</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">.</div><div class="ident">Printf</div><div class="operator">(</div><div class="ident">expectedStrInfoLevel</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">`\&#34;level\&#34;:\&#34;info\&#34;`</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">expectedStrInfoLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="ident">t</div><div class="operator">.</div><div class="ident">Run</div><div class="operator">(</div><div class="literal">&#34;ErrorLevel&#34;</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="ident">buf</div><div class="operator">.</div><div class="ident">Reset</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">sarama</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">.</div><div class="ident">Print</div><div class="operator">(</div><div class="ident">expectedErrStrErrorLevel</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">`\&#34;level\&#34;:\&#34;error\&#34;`</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">expectedErrStrErrorLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestLoggerSetLogLevel</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">logLevels</div> <div class="operator">:=</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">string</div><div class="operator">{</div><div class="literal">&#34;debug&#34;</div><div class="operator">,</div> <div class="literal">&#34;info&#34;</div><div class="operator">,</div> <div class="literal">&#34;warning&#34;</div><div class="operator">,</div> <div class="literal">&#34;error&#34;</div><div class="operator">}</div><div class="operator"></div>
+	<div class="keyword">for</div> <div class="ident">logLevelIndex</div><div class="operator">,</div> <div class="ident">logLevel</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">logLevels</div> <div class="operator">{</div>
+		<div class="ident">t</div><div class="operator">.</div><div class="ident">Run</div><div class="operator">(</div><div class="ident">logLevel</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+			<div class="ident">buf</div> <div class="operator">:=</div> <div class="ident">new</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">.</div><div class="ident">Buffer</div><div class="operator">)</div><div class="operator"></div>
+
+			<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div>
+				<div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+					<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
+					<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="ident">logLevel</div><div class="operator">,</div>
+					<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
+				<div class="operator">}</div><div class="operator">,</div>
+				<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+				<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">buf</div><div class="operator">)</div><div class="operator">,</div>
+			<div class="operator">)</div><div class="operator"></div>
+			<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+
+			<div class="ident">log</div><div class="operator">.</div><div class="ident">Debug</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;debug level&#34;</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;info level&#34;</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">log</div><div class="operator">.</div><div class="ident">Warn</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;warning level&#34;</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;error level&#34;</div><div class="operator">)</div><div class="operator"></div>
+
+			<div class="keyword">for</div> <div class="ident">i</div> <div class="operator">:=</div> <div class="literal">0</div><div class="operator">;</div> <div class="ident">i</div> <div class="operator">&lt;</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">logLevels</div><div class="operator">)</div><div class="operator">;</div> <div class="ident">i</div><div class="operator">&#43;&#43;</div> <div class="operator">{</div>
+				<div class="keyword">if</div> <div class="ident">i</div> <div class="operator">&lt;</div> <div class="ident">logLevelIndex</div> <div class="operator">{</div>
+					<div class="ident">assert</div><div class="operator">.</div><div class="ident">NotContains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">logLevels</div><div class="operator">[</div><div class="ident">i</div><div class="operator">]</div><div class="operator">&#43;</div><div class="literal">&#34; level&#34;</div><div class="operator">)</div><div class="operator"></div>
+				<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+					<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">logLevels</div><div class="operator">[</div><div class="ident">i</div><div class="operator">]</div><div class="operator">&#43;</div><div class="literal">&#34; level&#34;</div><div class="operator">)</div><div class="operator"></div>
+				<div class="operator">}</div><div class="operator"></div>
+			<div class="operator">}</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestWorkaroundForRHIOPS729_Write</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">for</div> <div class="ident">_</div><div class="operator">,</div> <div class="ident">testCase</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="operator">[</div><div class="operator">]</div><div class="keyword">struct</div> <div class="operator">{</div>
+		<div class="ident">Name</div>        <div class="ident">string</div><div class="operator"></div>
+		<div class="ident">StrToWrite</div>  <div class="ident">string</div><div class="operator"></div>
+		<div class="ident">ExpectedStr</div> <div class="ident">string</div><div class="operator"></div>
+		<div class="ident">IsJSON</div>      <div class="ident">bool</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator">{</div>
+		<div class="operator">{</div><div class="literal">&#34;NotJSON&#34;</div><div class="operator">,</div> <div class="literal">&#34;some expected string&#34;</div><div class="operator">,</div> <div class="literal">&#34;some expected string&#34;</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="operator">{</div>
+			<div class="literal">&#34;JSON&#34;</div><div class="operator">,</div>
+			<div class="literal">`{&#34;level&#34;: &#34;error&#34;, &#34;is_something&#34;: true}`</div><div class="operator">,</div>
+			<div class="literal">`{&#34;LEVEL&#34;:&#34;error&#34;, &#34;IS_SOMETHING&#34;: true}`</div><div class="operator">,</div>
+			<div class="ident">true</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div>
+	<div class="operator">}</div> <div class="operator">{</div>
+		<div class="ident">t</div><div class="operator">.</div><div class="ident">Run</div><div class="operator">(</div><div class="ident">testCase</div><div class="operator">.</div><div class="ident">Name</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+			<div class="ident">buf</div> <div class="operator">:=</div> <div class="ident">new</div><div class="operator">(</div><div class="ident">bytes</div><div class="operator">.</div><div class="ident">Buffer</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">unJSONWriter</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">WorkaroundForRHIOPS729</div><div class="operator">{</div><div class="ident">Writer</div><div class="operator">:</div> <div class="ident">buf</div><div class="operator">}</div><div class="operator"></div>
+
+			<div class="ident">writtenBytes</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">unJSONWriter</div><div class="operator">.</div><div class="ident">Write</div><div class="operator">(</div><div class="operator">[</div><div class="operator">]</div><div class="ident">byte</div><div class="operator">(</div><div class="ident">testCase</div><div class="operator">.</div><div class="ident">StrToWrite</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+			<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+
+			<div class="ident">assert</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">writtenBytes</div><div class="operator">,</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">testCase</div><div class="operator">.</div><div class="ident">StrToWrite</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+			<div class="keyword">if</div> <div class="ident">testCase</div><div class="operator">.</div><div class="ident">IsJSON</div> <div class="operator">{</div>
+				<div class="ident">helpers</div><div class="operator">.</div><div class="ident">AssertStringsAreEqualJSON</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testCase</div><div class="operator">.</div><div class="ident">ExpectedStr</div><div class="operator">,</div> <div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+			<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+				<div class="ident">assert</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testCase</div><div class="operator">.</div><div class="ident">ExpectedStr</div><div class="operator">,</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">TrimSpace</div><div class="operator">(</div><div class="ident">buf</div><div class="operator">.</div><div class="ident">String</div><div class="operator">(</div><div class="operator">)</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+			<div class="operator">}</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestInitZerolog_LogToCloudWatch</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
+			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
+			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">true</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator"></div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestLoggingToCloudwatch</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">RunTestWithTimeout</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="ident">testing</div><div class="operator">.</div><div class="ident">TB</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">defer</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CleanAfterGock</div><div class="operator">(</div><div class="ident">t</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">const</div> <div class="ident">baseURL</div> <div class="operator">=</div> <div class="literal">&#34;http://localhost:9999&#34;</div><div class="operator"></div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">AWSCloudWatchEndpoint</div> <div class="operator">=</div> <div class="ident">baseURL</div> <div class="operator">&#43;</div> <div class="literal">&#34;/cloudwatch&#34;</div><div class="operator"></div>
+
+		<div class="ident">expects</div> <div class="operator">:=</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">CloudWatchExpect</div><div class="operator">{</div>
+			<div class="operator">{</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">MethodPost</div><div class="operator">,</div>
+				<div class="literal">&#34;Logs_20140328.CreateLogStream&#34;</div><div class="operator">,</div>
+				<div class="literal">`{
+					&#34;logGroupName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;logStreamName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;
+				}`</div><div class="operator">,</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">StatusBadRequest</div><div class="operator">,</div>
+				<div class="literal">`{
+					&#34;__type&#34;: &#34;ResourceAlreadyExistsException&#34;,
+					&#34;message&#34;: &#34;The specified log stream already exists&#34;
+				}`</div><div class="operator">,</div>
+			<div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">describeLogStreamsEvent</div><div class="operator">,</div>
+			<div class="operator">{</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">MethodPost</div><div class="operator">,</div>
+				<div class="literal">&#34;Logs_20140328.PutLogEvents&#34;</div><div class="operator">,</div>
+				<div class="literal">`{
+					&#34;logEvents&#34;: [
+						{
+							&#34;message&#34;: &#34;test message text goes right here&#34;,
+							&#34;timestamp&#34;: 1
+						}
+					],
+					&#34;logGroupName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;logStreamName&#34;:&#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;sequenceToken&#34;:&#34;1&#34;
+				}`</div><div class="operator">,</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+				<div class="literal">`{&#34;nextSequenceToken&#34;:&#34;2&#34;}`</div><div class="operator">,</div>
+			<div class="operator">}</div><div class="operator">,</div>
+			<div class="operator">{</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">MethodPost</div><div class="operator">,</div>
+				<div class="literal">&#34;Logs_20140328.PutLogEvents&#34;</div><div class="operator">,</div>
+				<div class="literal">`{
+					&#34;logEvents&#34;: [
+						{
+							&#34;message&#34;: &#34;second test message text goes right here&#34;,
+							&#34;timestamp&#34;: 2
+						}
+					],
+					&#34;logGroupName&#34;: &#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;logStreamName&#34;:&#34;`</div> <div class="operator">&#43;</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">&#43;</div> <div class="literal">`&#34;,
+					&#34;sequenceToken&#34;:&#34;2&#34;
+				}`</div><div class="operator">,</div>
+				<div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+				<div class="literal">`{&#34;nextSequenceToken&#34;:&#34;3&#34;}`</div><div class="operator">,</div>
+			<div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">describeLogStreamsEvent</div><div class="operator">,</div>
+			<div class="ident">describeLogStreamsEvent</div><div class="operator">,</div>
+			<div class="ident">describeLogStreamsEvent</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="keyword">for</div> <div class="ident">_</div><div class="operator">,</div> <div class="ident">expect</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">expects</div> <div class="operator">{</div>
+			<div class="ident">helpers</div><div class="operator">.</div><div class="ident">GockExpectAPIRequest</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">baseURL</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIRequest</div><div class="operator">{</div>
+				<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">expect</div><div class="operator">.</div><div class="ident">ExpectedMethod</div><div class="operator">,</div>
+				<div class="ident">Body</div><div class="operator">:</div>     <div class="ident">expect</div><div class="operator">.</div><div class="ident">ExpectedBody</div><div class="operator">,</div>
+				<div class="ident">Endpoint</div><div class="operator">:</div> <div class="literal">&#34;cloudwatch/&#34;</div><div class="operator">,</div>
+				<div class="ident">ExtraHeaders</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">Header</div><div class="operator">{</div>
+					<div class="literal">&#34;X-Amz-Target&#34;</div><div class="operator">:</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">string</div><div class="operator">{</div><div class="ident">expect</div><div class="operator">.</div><div class="ident">ExpectedTarget</div><div class="operator">}</div><div class="operator">,</div>
+				<div class="operator">}</div><div class="operator">,</div>
+			<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
+				<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">expect</div><div class="operator">.</div><div class="ident">ResultStatusCode</div><div class="operator">,</div>
+				<div class="ident">Body</div><div class="operator">:</div>       <div class="ident">expect</div><div class="operator">.</div><div class="ident">ResultBody</div><div class="operator">,</div>
+				<div class="ident">Headers</div><div class="operator">:</div> <div class="keyword">map</div><div class="operator">[</div><div class="ident">string</div><div class="operator">]</div><div class="ident">string</div><div class="operator">{</div>
+					<div class="literal">&#34;Content-Type&#34;</div><div class="operator">:</div> <div class="literal">&#34;application/x-amz-json-1.1&#34;</div><div class="operator">,</div>
+				<div class="operator">}</div><div class="operator">,</div>
+			<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
+			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
+			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">true</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;test message&#34;</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator">,</div> <div class="ident">testTimeout</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/RedHatInsights/insights-operator-utils
 go 1.13
 
 require (
+	github.com/RedHatInsights/cloudwatch v0.0.0-20200512151223-b0b55757a24b
 	github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc
+	github.com/Shopify/sarama v1.26.0
+	github.com/aws/aws-sdk-go v1.30.25
 	github.com/getkin/kin-openapi v0.20.0
 	github.com/golang/mock v1.4.3
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.7/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/RedHatInsights/cloudwatch v0.0.0-20200512151223-b0b55757a24b h1:IFT3csatW9XMCEi54wRo+GiFshT4E2V2vWCKYg7413w=
 github.com/RedHatInsights/cloudwatch v0.0.0-20200512151223-b0b55757a24b/go.mod h1:8l+HqU8iWM6hA9kSAHgY3ItSlpEsPr8fb2R0GBp9S0U=
 github.com/RedHatInsights/insights-content-service v0.0.0-20200619153839-23a428468a08 h1:hsmKH/lhX5KW1IIvjicC1lyTOt4t9RMjrGJkHuSDHN8=
 github.com/RedHatInsights/insights-content-service v0.0.0-20200619153839-23a428468a08/go.mod h1:CSzDwoJXMIPnRNOZfYn68YbXejRqSr0i4uqtB6oLYt4=
@@ -29,6 +30,7 @@ github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc h1:YW3dZHVYKUEzADsBF+m3BdrGxGZM0Xb3UAByJIBT9Cw=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
+github.com/Shopify/sarama v1.26.0 h1:C+zFi+/NJdfeJgZWbu+WaLgk4NcsbmqfFTKsoJmR39U=
 github.com/Shopify/sarama v1.26.0/go.mod h1:y/CFFTO9eaMTNriwu/Q+W4eioLqiDMGkA1W+gmdfj8w=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -49,6 +51,7 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.30.25 h1:89NXJkfpjnMEnsxkP8MVX+LDsoiLCSqevraLb5y4Mjk=
 github.com/aws/aws-sdk-go v1.30.25/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -95,8 +98,11 @@ github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14y
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/eapache/go-resiliency v1.1.0 h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
+github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
+github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
@@ -152,6 +158,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -207,6 +214,7 @@ github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
@@ -227,9 +235,11 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 h1:FUwcHNlEqkqLjLBdCp5PRlCFijNjvcYANOZXzCfXwCM=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcxplorer/cwlogger v0.0.0-20170704082755-4e30a5a47e6a/go.mod h1:jqP/JbBwy+LLLUwzr8XTr9IrnaNxFD7kmaXZlvjH9nQ=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -241,6 +251,7 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.9.7 h1:hYW1gP94JUmAhBtJ+LNz5My+gBobDxPR1iVuKug26aA=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -321,6 +332,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.2.6+incompatible h1:6aCX4/YZ9v8q69hTyiR7dNLnTA3fgtKHVVW5BCd5Znw=
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -361,6 +373,7 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -447,6 +460,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f h1:kz4KIr+xcPUsI3VMoqWfPMvtnJ6MGfiVwsWSVzphMO4=
 golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -618,10 +632,14 @@ gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/h2non/gock.v1 v1.0.15 h1:SzLqcIlb/fDfg7UvukMpNcWsu7sI5tWwL+KCATZqks0=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
+gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eRhxkJMWSIz9Q=
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
+gopkg.in/jcmturner/gokrb5.v7 v7.2.3 h1:hHMV/yKPwMnJhPuPx7pH2Uw/3Qyf+thJYlisUc44010=
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
+gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/logger/configuration.go
+++ b/logger/configuration.go
@@ -1,0 +1,51 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logger
+
+// LoggingConfiguration represents configuration for logging in general
+type LoggingConfiguration struct {
+	// Debug enables pretty colored logging
+	Debug bool `mapstructure:"debug" toml:"debug"`
+
+	// LogLevel sets logging level to show. Possible values are:
+	// "debug"
+	// "info"
+	// "warn", "warning"
+	// "error"
+	// "fatal"
+	//
+	// logging level won't be changed if value is not one of listed above
+	LogLevel string `mapstructure:"log_level" toml:"log_level"`
+
+	// LoggingToCloudWatchEnabled enables logging to CloudWatch
+	// (configuration for CloudWatch is in CloudWatchConfiguration)
+	LoggingToCloudWatchEnabled bool `mapstructure:"logging_to_cloud_watch_enabled" toml:"logging_to_cloud_watch_enabled"`
+}
+
+// CloudWatchConfiguration represents configuration of CloudWatch logger
+type CloudWatchConfiguration struct {
+	AWSAccessID             string `mapstructure:"aws_access_id" toml:"aws_access_id"`
+	AWSSecretKey            string `mapstructure:"aws_secret_key" toml:"aws_secret_key"`
+	AWSSessionToken         string `mapstructure:"aws_session_token" toml:"aws_session_token"`
+	AWSRegion               string `mapstructure:"aws_region" toml:"aws_region"`
+	LogGroup                string `mapstructure:"log_group" toml:"log_group"`
+	StreamName              string `mapstructure:"stream_name" toml:"stream_name"`
+	CreateStreamIfNotExists bool   `mapstructure:"create_stream_if_not_exists" toml:"create_stream_if_not_exists"`
+
+	// enable debug logs for debugging aws client itself
+	Debug bool `mapstructure:"debug" toml:"debug"`
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,205 @@
+/*
+Copyright © 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logger contains the configuration structures needed to configure
+// the access to CloudWatch server to sending the log messages there.
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/RedHatInsights/cloudwatch"
+	"github.com/Shopify/sarama"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// WorkaroundForRHIOPS729 keeps only those fields that are currently getting their way to Kibana
+// TODO: delete when RHIOPS-729 is fixed
+type WorkaroundForRHIOPS729 struct {
+	io.Writer
+}
+
+func (writer WorkaroundForRHIOPS729) Write(bytes []byte) (int, error) {
+	var obj map[string]interface{}
+
+	err := json.Unmarshal(bytes, &obj)
+	if err != nil {
+		// it's not JSON object, so we don't do anything
+		return writer.Writer.Write(bytes)
+	}
+
+	// lowercase the keys
+	for key := range obj {
+		val := obj[key]
+		delete(obj, key)
+		obj[strings.ToUpper(key)] = val
+	}
+
+	resultBytes, err := json.Marshal(obj)
+	if err != nil {
+		return 0, err
+	}
+
+	written, err := writer.Writer.Write(resultBytes)
+	if err != nil {
+		return written, err
+	}
+
+	if written < len(resultBytes) {
+		return written, fmt.Errorf("too few bytes were written")
+	}
+
+	return len(bytes), nil
+}
+
+// AWSCloudWatchEndpoint allows you to mock cloudwatch client by redirecting requests to a local proxy
+var AWSCloudWatchEndpoint string
+
+// InitZerolog initializes zerolog with provided configs to use proper stdout and/or CloudWatch logging
+func InitZerolog(
+	loggingConf LoggingConfiguration, cloudWatchConf CloudWatchConfiguration, additionalWriters ...io.Writer,
+) error {
+	setGlobalLogLevel(loggingConf)
+
+	var writers []io.Writer
+
+	writers = append(writers, additionalWriters...)
+
+	if loggingConf.Debug {
+		// nice colored output
+		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stdout})
+	} else {
+		writers = append(writers, os.Stdout)
+	}
+
+	cloudWatchConf.StreamName = strings.ReplaceAll(cloudWatchConf.StreamName, "$HOSTNAME", os.Getenv("HOSTNAME"))
+
+	if loggingConf.LoggingToCloudWatchEnabled {
+		awsLogLevel := aws.LogOff
+		if cloudWatchConf.Debug {
+			awsLogLevel = aws.LogDebugWithSigning |
+				aws.LogDebugWithSigning |
+				aws.LogDebugWithHTTPBody |
+				aws.LogDebugWithEventStreamBody
+		}
+
+		awsConf := aws.NewConfig().
+			WithCredentials(credentials.NewStaticCredentials(
+				cloudWatchConf.AWSAccessID, cloudWatchConf.AWSSecretKey, cloudWatchConf.AWSSessionToken,
+			)).
+			WithRegion(cloudWatchConf.AWSRegion).
+			WithLogLevel(awsLogLevel)
+
+		if len(AWSCloudWatchEndpoint) > 0 {
+			awsConf = awsConf.WithEndpoint(AWSCloudWatchEndpoint)
+		}
+
+		cloudWatchSession := session.Must(session.NewSession(awsConf))
+		CloudWatchClient := cloudwatchlogs.New(cloudWatchSession)
+
+		var cloudWatchWriter io.Writer
+		if cloudWatchConf.CreateStreamIfNotExists {
+			group := cloudwatch.NewGroup(cloudWatchConf.LogGroup, CloudWatchClient)
+
+			var err error
+			cloudWatchWriter, err = group.Create(cloudWatchConf.StreamName)
+			if err != nil {
+				return err
+			}
+		} else {
+			cloudWatchWriter = cloudwatch.NewWriter(
+				cloudWatchConf.LogGroup, cloudWatchConf.StreamName, CloudWatchClient,
+			)
+		}
+
+		writers = append(writers, &WorkaroundForRHIOPS729{Writer: cloudWatchWriter})
+	}
+
+	logsWriter := io.MultiWriter(writers...)
+
+	log.Logger = zerolog.New(logsWriter).With().Timestamp().Logger()
+
+	// zerolog doesn't implement Println required by sarama
+	sarama.Logger = &SaramaZerologger{zerologger: log.Logger}
+
+	return nil
+}
+
+func setGlobalLogLevel(configuration LoggingConfiguration) {
+	logLevel := strings.ToLower(strings.TrimSpace(configuration.LogLevel))
+
+	switch logLevel {
+	case "debug":
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case "info":
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	case "warn", "warning":
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	case "error":
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	case "fatal":
+		zerolog.SetGlobalLevel(zerolog.FatalLevel)
+	}
+}
+
+const kafkaErrorPrefix = "kafka: error"
+
+// SaramaZerologger is a wrapper to make sarama log to zerolog
+// those logs can be filtered by key "package" with value "sarama"
+type SaramaZerologger struct{ zerologger zerolog.Logger }
+
+// Print wraps print method
+func (logger *SaramaZerologger) Print(params ...interface{}) {
+	var messages []string
+	for _, item := range params {
+		messages = append(messages, fmt.Sprint(item))
+	}
+
+	logger.logMessage("%v", strings.Join(messages, " "))
+}
+
+// Printf wraps printf method
+func (logger *SaramaZerologger) Printf(format string, params ...interface{}) {
+	logger.logMessage(format, params...)
+}
+
+// Println wraps println method
+func (logger *SaramaZerologger) Println(v ...interface{}) {
+	logger.Print(v...)
+}
+
+func (logger *SaramaZerologger) logMessage(format string, params ...interface{}) {
+	var event *zerolog.Event
+	messageStr := fmt.Sprintf(format, params...)
+
+	if strings.HasPrefix(messageStr, kafkaErrorPrefix) {
+		event = logger.zerologger.Error()
+	} else {
+		event = logger.zerologger.Info()
+	}
+
+	event = event.Str("package", "sarama")
+	event.Msg(messageStr)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,285 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger_test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/insights-operator-utils/logger"
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
+	"github.com/Shopify/sarama"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testTimeout = 10 * time.Second
+)
+
+var (
+	cloudWatchConf = logger.CloudWatchConfiguration{
+		AWSAccessID:             "access ID",
+		AWSSecretKey:            "secret",
+		AWSSessionToken:         "sess token",
+		AWSRegion:               "aws region",
+		LogGroup:                "log group",
+		StreamName:              "stream name",
+		CreateStreamIfNotExists: true,
+		Debug:                   false,
+	}
+	describeLogStreamsEvent = CloudWatchExpect{
+		http.MethodPost,
+		"Logs_20140328.DescribeLogStreams",
+		`{
+					"descending": false,
+					"logGroupName": "` + cloudWatchConf.LogGroup + `",
+					"logStreamNamePrefix": "` + cloudWatchConf.StreamName + `",
+					"orderBy": "LogStreamName"
+				}`,
+		http.StatusOK,
+		`{
+					"logStreams": [
+						{
+							"arn": "arn:aws:logs:` +
+			cloudWatchConf.AWSRegion + `:012345678910:log-group:` + cloudWatchConf.LogGroup +
+			`:log-stream:` + cloudWatchConf.StreamName + `",
+							"creationTime": 1,
+							"firstEventTimestamp": 2,
+							"lastEventTimestamp": 3,
+							"lastIngestionTime": 4,
+							"logStreamName": "` + cloudWatchConf.StreamName + `",
+							"storedBytes": 100,
+							"uploadSequenceToken": "1"
+						}
+					],
+					"nextToken": "token1"
+				}`,
+	}
+)
+
+type CloudWatchExpect struct {
+	ExpectedMethod   string
+	ExpectedTarget   string
+	ExpectedBody     string
+	ResultStatusCode int
+	ResultBody       string
+}
+
+func TestSaramaZerologger(t *testing.T) {
+	const expectedStrInfoLevel = "some random message"
+	const expectedErrStrErrorLevel = "kafka: error test error"
+
+	buf := new(bytes.Buffer)
+
+	err := logger.InitZerolog(
+		logger.LoggingConfiguration{
+			Debug:                      false,
+			LogLevel:                   "debug",
+			LoggingToCloudWatchEnabled: false,
+		},
+		logger.CloudWatchConfiguration{},
+		zerolog.New(buf),
+	)
+	helpers.FailOnError(t, err)
+
+	t.Run("InfoLevel", func(t *testing.T) {
+		buf.Reset()
+
+		sarama.Logger.Printf(expectedStrInfoLevel)
+
+		assert.Contains(t, buf.String(), `\"level\":\"info\"`)
+		assert.Contains(t, buf.String(), expectedStrInfoLevel)
+	})
+
+	t.Run("ErrorLevel", func(t *testing.T) {
+		buf.Reset()
+
+		sarama.Logger.Print(expectedErrStrErrorLevel)
+
+		assert.Contains(t, buf.String(), `\"level\":\"error\"`)
+		assert.Contains(t, buf.String(), expectedErrStrErrorLevel)
+	})
+}
+
+func TestLoggerSetLogLevel(t *testing.T) {
+	logLevels := []string{"debug", "info", "warning", "error"}
+	for logLevelIndex, logLevel := range logLevels {
+		t.Run(logLevel, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+
+			err := logger.InitZerolog(
+				logger.LoggingConfiguration{
+					Debug:                      false,
+					LogLevel:                   logLevel,
+					LoggingToCloudWatchEnabled: false,
+				},
+				logger.CloudWatchConfiguration{},
+				zerolog.New(buf),
+			)
+			helpers.FailOnError(t, err)
+
+			log.Debug().Msg("debug level")
+			log.Info().Msg("info level")
+			log.Warn().Msg("warning level")
+			log.Error().Msg("error level")
+
+			for i := 0; i < len(logLevels); i++ {
+				if i < logLevelIndex {
+					assert.NotContains(t, buf.String(), logLevels[i]+" level")
+				} else {
+					assert.Contains(t, buf.String(), logLevels[i]+" level")
+				}
+			}
+		})
+	}
+}
+
+func TestWorkaroundForRHIOPS729_Write(t *testing.T) {
+	for _, testCase := range []struct {
+		Name        string
+		StrToWrite  string
+		ExpectedStr string
+		IsJSON      bool
+	}{
+		{"NotJSON", "some expected string", "some expected string", false},
+		{
+			"JSON",
+			`{"level": "error", "is_something": true}`,
+			`{"LEVEL":"error", "IS_SOMETHING": true}`,
+			true,
+		},
+	} {
+		t.Run(testCase.Name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			unJSONWriter := logger.WorkaroundForRHIOPS729{Writer: buf}
+
+			writtenBytes, err := unJSONWriter.Write([]byte(testCase.StrToWrite))
+			helpers.FailOnError(t, err)
+
+			assert.Equal(t, writtenBytes, len(testCase.StrToWrite))
+			if testCase.IsJSON {
+				helpers.AssertStringsAreEqualJSON(t, testCase.ExpectedStr, buf.String())
+			} else {
+				assert.Equal(t, testCase.ExpectedStr, strings.TrimSpace(buf.String()))
+			}
+		})
+	}
+}
+
+func TestInitZerolog_LogToCloudWatch(t *testing.T) {
+	err := logger.InitZerolog(
+		logger.LoggingConfiguration{
+			Debug:                      false,
+			LogLevel:                   "debug",
+			LoggingToCloudWatchEnabled: true,
+		},
+		logger.CloudWatchConfiguration{},
+	)
+	helpers.FailOnError(t, err)
+}
+
+func TestLoggingToCloudwatch(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		const baseURL = "http://localhost:9999"
+		logger.AWSCloudWatchEndpoint = baseURL + "/cloudwatch"
+
+		expects := []CloudWatchExpect{
+			{
+				http.MethodPost,
+				"Logs_20140328.CreateLogStream",
+				`{
+					"logGroupName": "` + cloudWatchConf.LogGroup + `",
+					"logStreamName": "` + cloudWatchConf.StreamName + `"
+				}`,
+				http.StatusBadRequest,
+				`{
+					"__type": "ResourceAlreadyExistsException",
+					"message": "The specified log stream already exists"
+				}`,
+			},
+			describeLogStreamsEvent,
+			{
+				http.MethodPost,
+				"Logs_20140328.PutLogEvents",
+				`{
+					"logEvents": [
+						{
+							"message": "test message text goes right here",
+							"timestamp": 1
+						}
+					],
+					"logGroupName": "` + cloudWatchConf.LogGroup + `",
+					"logStreamName":"` + cloudWatchConf.StreamName + `",
+					"sequenceToken":"1"
+				}`,
+				http.StatusOK,
+				`{"nextSequenceToken":"2"}`,
+			},
+			{
+				http.MethodPost,
+				"Logs_20140328.PutLogEvents",
+				`{
+					"logEvents": [
+						{
+							"message": "second test message text goes right here",
+							"timestamp": 2
+						}
+					],
+					"logGroupName": "` + cloudWatchConf.LogGroup + `",
+					"logStreamName":"` + cloudWatchConf.StreamName + `",
+					"sequenceToken":"2"
+				}`,
+				http.StatusOK,
+				`{"nextSequenceToken":"3"}`,
+			},
+			describeLogStreamsEvent,
+			describeLogStreamsEvent,
+			describeLogStreamsEvent,
+		}
+
+		for _, expect := range expects {
+			helpers.GockExpectAPIRequest(t, baseURL, &helpers.APIRequest{
+				Method:   expect.ExpectedMethod,
+				Body:     expect.ExpectedBody,
+				Endpoint: "cloudwatch/",
+				ExtraHeaders: http.Header{
+					"X-Amz-Target": []string{expect.ExpectedTarget},
+				},
+			}, &helpers.APIResponse{
+				StatusCode: expect.ResultStatusCode,
+				Body:       expect.ResultBody,
+				Headers: map[string]string{
+					"Content-Type": "application/x-amz-json-1.1",
+				},
+			})
+		}
+
+		err := logger.InitZerolog(logger.LoggingConfiguration{
+			Debug:                      false,
+			LogLevel:                   "debug",
+			LoggingToCloudWatchEnabled: true,
+		}, cloudWatchConf)
+		helpers.FailOnError(t, err)
+
+		log.Error().Msg("test message")
+	}, testTimeout)
+}


### PR DESCRIPTION
# Description

Moving CloudWatch logging from Insights Results Aggregator to this project in order to be used by the different services

All the external data pipeline services written in Go should log into Cloudwatch, in order to get their logs on Kibana. As we already have one implementation in Insights Results Aggregator, I'm going to copy the source code here in order to be reused by the rest of the services

## Type of change
- New feature (non-breaking change which adds functionality)

## Testing steps

Regular CI