### PR TITLE
GitHub action to auto-generate release when tags are pushed

### DIFF
--- a/.github/workflows/release_workflow.yaml
+++ b/.github/workflows/release_workflow.yaml
@@ -1,0 +1,27 @@
+name: CI for releasing tagged versions
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build_dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract tag name
+        id: tag
+        run: |
+          echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.TAG }}
+          release_name: Release ${{ steps.tag.outputs.TAG }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
# Description

Adding GitHub workflow in order to autogenerate the release when a new tag is pushed in the repository.

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps
This PR doesn't affect to current files or documentation in the repository. It should work only when a new tag is pushed to the repository by anyone