### PR TITLE
Add SchemaVersion type

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -212,3 +212,7 @@ type ClusterReports struct {
 	GeneratedAt string                      `json:"generated_at"`
 	Status      string                      `json:"status"`
 }
+
+//Version is just a constant integer for now, max value 255. If we one day
+//need more versions, better consider upgrading to semantic versioning.
+type SchemaVersion uint8

--- a/types/types.go
+++ b/types/types.go
@@ -213,6 +213,6 @@ type ClusterReports struct {
 	Status      string                      `json:"status"`
 }
 
-//Version is just a constant integer for now, max value 255. If we one day
+//SchemaVersion is just a constant integer for now, max value 255. If we one day
 //need more versions, better consider upgrading to semantic versioning.
 type SchemaVersion uint8


### PR DESCRIPTION
# Description

Added SchemaVersion as a type in insights-operator-utils so we can use it in insights-results-aggregator and insights-results-aggregator-data repositories. This change is needed to fix https://github.com/RedHatInsights/insights-results-aggregator/issues/1091

## Type of change

- Bug fix (non-breaking change which fixes an issue)

