### PR TITLE
Using MultiLevelWriter to enable clients to use LevelWriters

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -150,7 +150,7 @@ func InitZerolog(
 		needClose = append(needClose, sentryWriter)
 	}
 
-	logsWriter := io.MultiWriter(writers...)
+	logsWriter := zerolog.MultiLevelWriter(writers...)
 
 	log.Logger = zerolog.New(logsWriter).With().Timestamp().Logger()
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -301,3 +301,18 @@ func TestInitZerolog_LogToSentry(t *testing.T) {
 	}, logger.CloudWatchConfiguration{}, sentryConf)
 	helpers.FailOnError(t, err)
 }
+
+func TestCloseZerolog(t *testing.T) {
+	sentryConf := logger.SentryLoggingConfiguration{
+		SentryDSN: "http://hash@localhost:9999/project/1",
+	}
+
+	err := logger.InitZerolog(logger.LoggingConfiguration{
+		Debug:                      false,
+		LogLevel:                   "debug",
+		LoggingToCloudWatchEnabled: false,
+		LoggingToSentryEnabled:     true,
+	}, logger.CloudWatchConfiguration{}, sentryConf)
+	helpers.FailOnError(t, err)
+	logger.CloseZerolog()
+}


### PR DESCRIPTION
# Description

`zerolog` allows to use `io.Writer` interface or `zerolog.LevelWriter`, that enables de implementation of the writer to handle the level of the message. In order to being able to use the later, a `zerolog.MultiLevelWriter` should be used instead of `io.Writer`

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Regular CI