### PR TITLE
Adding support for using Kafka topic to send log messages

### DIFF
--- a/docs/packages/logger/configuration.html
+++ b/docs/packages/logger/configuration.html
@@ -135,6 +135,8 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">logger</div><div class="operator"></div>
 
+<div class="keyword">import</div> <div class="literal">&#34;github.com/rs/zerolog&#34;</div><div class="operator"></div>
+
 </code></pre></td>
       </tr>
       
@@ -183,6 +185,15 @@ limitations under the License.
 (configuration for Sentry is in SentryLoggingConfiguration)</p>
 </td>
 	<td class="code"><pre><code>	<div class="ident">LoggingToSentryEnabled</div> <div class="ident">bool</div> <div class="literal">`mapstructure:&#34;logging_to_sentry_enabled&#34; toml:&#34;logging_to_sentry_enabled&#34;`</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>LoggingToKafkaEnabled enables logging to Kafka
+(configuration for Kafka logging is in KafkaZerologConfiguration)</p>
+</td>
+	<td class="code"><pre><code>	<div class="ident">LoggingToKafkaEnabled</div> <div class="ident">bool</div> <div class="literal">`mapstructure:&#34;logging_to_kafka_enabled&#34; toml:&#34;logging_to_kafka_enabled&#34;`</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>
@@ -217,6 +228,19 @@ limitations under the License.
 </td>
 	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">SentryLoggingConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
 	<div class="ident">SentryDSN</div> <div class="ident">string</div> <div class="literal">`mapstructure:&#34;dsn&#34; toml:&#34;dsn&#34;`</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>KafkaZerologConfiguration represetns the configuration for sending log messages to a Kafka topic</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">KafkaZerologConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
+	<div class="ident">Broker</div>   <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;broker&#34; toml:&#34;broker&#34;`</div><div class="operator"></div>
+	<div class="ident">Topic</div>    <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;topic&#34; toml:&#34;topic&#34;`</div><div class="operator"></div>
+	<div class="ident">CertPath</div> <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;cert_path&#34; toml:&#34;cert_path&#34;`</div><div class="operator"></div>
+	<div class="ident">Level</div>    <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">Level</div> <div class="literal">`mapstructure:&#34;level&#34; toml:&#34;level&#34;`</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/docs/packages/logger/logger.html
+++ b/docs/packages/logger/logger.html
@@ -150,6 +150,7 @@ the access to CloudWatch server to sending the log messages there.</p>
 	<div class="literal">&#34;strings&#34;</div><div class="operator"></div>
 
 	<div class="literal">&#34;github.com/RedHatInsights/cloudwatch&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/RedHatInsights/kafka-zerolog/kafkazerolog&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/Shopify/sarama&#34;</div><div class="operator"></div>
 	<div class="ident">zlogsentry</div> <div class="literal">&#34;github.com/archdx/zerolog-sentry&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/aws/aws-sdk-go/aws&#34;</div><div class="operator"></div>
@@ -231,7 +232,8 @@ TODO: delete when RHIOPS-729 is fixed</p>
 	<td class="doc"><p>InitZerolog initializes zerolog with provided configs to use proper stdout and/or CloudWatch logging</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">InitZerolog</div><div class="operator">(</div>
-	<div class="ident">loggingConf</div> <div class="ident">LoggingConfiguration</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div> <div class="ident">CloudWatchConfiguration</div><div class="operator">,</div> <div class="ident">sentryConf</div> <div class="ident">SentryLoggingConfiguration</div><div class="operator">,</div> <div class="ident">additionalWriters</div> <div class="operator">...</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">,</div>
+	<div class="ident">loggingConf</div> <div class="ident">LoggingConfiguration</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div> <div class="ident">CloudWatchConfiguration</div><div class="operator">,</div> <div class="ident">sentryConf</div> <div class="ident">SentryLoggingConfiguration</div><div class="operator">,</div>
+	<div class="ident">kafkazerologConf</div> <div class="ident">KafkaZerologConfiguration</div><div class="operator">,</div> <div class="ident">additionalWriters</div> <div class="operator">...</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">,</div>
 <div class="operator">)</div> <div class="ident">error</div> <div class="operator">{</div>
 	<div class="ident">setGlobalLogLevel</div><div class="operator">(</div><div class="ident">loggingConf</div><div class="operator">)</div><div class="operator"></div>
 
@@ -244,6 +246,9 @@ TODO: delete when RHIOPS-729 is fixed</p>
 		<div class="ident">selectedOutput</div> <div class="operator">=</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Stderr</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
+	<div class="keyword">var</div> <div class="ident">consoleWriter</div> <div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
+	<div class="ident">consoleWriter</div> <div class="operator">=</div> <div class="ident">selectedOutput</div><div class="operator"></div>
+
 	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">Debug</div> <div class="operator">{</div>
 </code></pre></td>
       </tr>
@@ -251,66 +256,39 @@ TODO: delete when RHIOPS-729 is fixed</p>
       <tr class="section">
 	<td class="doc"><p>nice colored output</p>
 </td>
-	<td class="code"><pre><code>		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ConsoleWriter</div><div class="operator">{</div><div class="ident">Out</div><div class="operator">:</div> <div class="ident">selectedOutput</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
-	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
-		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">selectedOutput</div><div class="operator">)</div><div class="operator"></div>
+	<td class="code"><pre><code>		<div class="ident">consoleWriter</div> <div class="operator">=</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ConsoleWriter</div><div class="operator">{</div><div class="ident">Out</div><div class="operator">:</div> <div class="ident">selectedOutput</div><div class="operator">}</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ReplaceAll</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="literal">&#34;$HOSTNAME&#34;</div><div class="operator">,</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Getenv</div><div class="operator">(</div><div class="literal">&#34;HOSTNAME&#34;</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">consoleWriter</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">LoggingToCloudWatchEnabled</div> <div class="operator">{</div>
-		<div class="ident">awsLogLevel</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogOff</div><div class="operator"></div>
-		<div class="keyword">if</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">Debug</div> <div class="operator">{</div>
-			<div class="ident">awsLogLevel</div> <div class="operator">=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
-				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
-				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithHTTPBody</div> <div class="operator">|</div>
-				<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithEventStreamBody</div><div class="operator"></div>
-		<div class="operator">}</div><div class="operator"></div>
-
-		<div class="ident">awsConf</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">NewConfig</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div>
-			<div class="ident">WithCredentials</div><div class="operator">(</div><div class="ident">credentials</div><div class="operator">.</div><div class="ident">NewStaticCredentials</div><div class="operator">(</div>
-				<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSAccessID</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSSecretKey</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSSessionToken</div><div class="operator">,</div>
-			<div class="operator">)</div><div class="operator">)</div><div class="operator">.</div>
-			<div class="ident">WithRegion</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">AWSRegion</div><div class="operator">)</div><div class="operator">.</div>
-			<div class="ident">WithLogLevel</div><div class="operator">(</div><div class="ident">awsLogLevel</div><div class="operator">)</div><div class="operator"></div>
-
-		<div class="keyword">if</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div> <div class="operator">&gt;</div> <div class="literal">0</div> <div class="operator">{</div>
-			<div class="ident">awsConf</div> <div class="operator">=</div> <div class="ident">awsConf</div><div class="operator">.</div><div class="ident">WithEndpoint</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div><div class="operator"></div>
-		<div class="operator">}</div><div class="operator"></div>
-
-		<div class="ident">cloudWatchSession</div> <div class="operator">:=</div> <div class="ident">session</div><div class="operator">.</div><div class="ident">Must</div><div class="operator">(</div><div class="ident">session</div><div class="operator">.</div><div class="ident">NewSession</div><div class="operator">(</div><div class="ident">awsConf</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
-		<div class="ident">CloudWatchClient</div> <div class="operator">:=</div> <div class="ident">cloudwatchlogs</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">cloudWatchSession</div><div class="operator">)</div><div class="operator"></div>
-
-		<div class="keyword">var</div> <div class="ident">cloudWatchWriter</div> <div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
-		<div class="keyword">if</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">CreateStreamIfNotExists</div> <div class="operator">{</div>
-			<div class="ident">group</div> <div class="operator">:=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewGroup</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">)</div><div class="operator"></div>
-
-			<div class="keyword">var</div> <div class="ident">err</div> <div class="ident">error</div><div class="operator"></div>
-			<div class="ident">cloudWatchWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">=</div> <div class="ident">group</div><div class="operator">.</div><div class="ident">Create</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">)</div><div class="operator"></div>
-			<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-				<div class="keyword">return</div> <div class="ident">err</div><div class="operator"></div>
-			<div class="operator">}</div><div class="operator"></div>
-		<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
-			<div class="ident">cloudWatchWriter</div> <div class="operator">=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewWriter</div><div class="operator">(</div>
-				<div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">,</div>
-			<div class="operator">)</div><div class="operator"></div>
+		<div class="ident">cloudWatchWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">setupCloudwatchLogging</div><div class="operator">(</div><div class="ident">cloudWatchConf</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+			<div class="keyword">return</div> <div class="ident">err</div><div class="operator"></div>
 		<div class="operator">}</div><div class="operator"></div>
 
 		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">WorkaroundForRHIOPS729</div><div class="operator">{</div><div class="ident">Writer</div><div class="operator">:</div> <div class="ident">cloudWatchWriter</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">LoggingToSentryEnabled</div> <div class="operator">{</div>
-		<div class="ident">sentryWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">zlogsentry</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">sentryConf</div><div class="operator">.</div><div class="ident">SentryDSN</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">sentryWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">setupSentryLogging</div><div class="operator">(</div><div class="ident">sentryConf</div><div class="operator">)</div><div class="operator"></div>
 		<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
 			<div class="keyword">return</div> <div class="ident">err</div><div class="operator"></div>
 		<div class="operator">}</div><div class="operator"></div>
-
 		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">sentryWriter</div><div class="operator">)</div><div class="operator"></div>
 		<div class="ident">needClose</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">needClose</div><div class="operator">,</div> <div class="ident">sentryWriter</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="ident">logsWriter</div> <div class="operator">:=</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">MultiLevelWriter</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">loggingConf</div><div class="operator">.</div><div class="ident">LoggingToKafkaEnabled</div> <div class="operator">{</div>
+		<div class="ident">kafkaWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">setupKafkaZerolog</div><div class="operator">(</div><div class="ident">kafkazerologConf</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+			<div class="keyword">return</div> <div class="ident">err</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+		<div class="ident">writers</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">,</div> <div class="ident">kafkaWriter</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">needClose</div> <div class="operator">=</div> <div class="ident">append</div><div class="operator">(</div><div class="ident">needClose</div><div class="operator">,</div> <div class="ident">kafkaWriter</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
 
+	<div class="ident">logsWriter</div> <div class="operator">:=</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">MultiLevelWriter</div><div class="operator">(</div><div class="ident">writers</div><div class="operator">...</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">log</div><div class="operator">.</div><div class="ident">Logger</div> <div class="operator">=</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">logsWriter</div><div class="operator">)</div><div class="operator">.</div><div class="ident">With</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Timestamp</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 
 </code></pre></td>
@@ -320,7 +298,6 @@ TODO: delete when RHIOPS-729 is fixed</p>
 	<td class="doc"><p>zerolog doesn't implement Println required by sarama</p>
 </td>
 	<td class="code"><pre><code>	<div class="ident">sarama</div><div class="operator">.</div><div class="ident">Logger</div> <div class="operator">=</div> <div class="operator">&amp;</div><div class="ident">SaramaZerologger</div><div class="operator">{</div><div class="ident">zerologger</div><div class="operator">:</div> <div class="ident">log</div><div class="operator">.</div><div class="ident">Logger</div><div class="operator">}</div><div class="operator"></div>
-
 	<div class="keyword">return</div> <div class="ident">nil</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
@@ -354,6 +331,66 @@ TODO: delete when RHIOPS-729 is fixed</p>
 	<div class="keyword">case</div> <div class="literal">&#34;fatal&#34;</div><div class="operator">:</div>
 		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">FatalLevel</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">setupCloudwatchLogging</div><div class="operator">(</div><div class="ident">conf</div> <div class="ident">CloudWatchConfiguration</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">,</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">conf</div><div class="operator">.</div><div class="ident">StreamName</div> <div class="operator">=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ReplaceAll</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="literal">&#34;$HOSTNAME&#34;</div><div class="operator">,</div> <div class="ident">os</div><div class="operator">.</div><div class="ident">Getenv</div><div class="operator">(</div><div class="literal">&#34;HOSTNAME&#34;</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">awsLogLevel</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogOff</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">Debug</div> <div class="operator">{</div>
+		<div class="ident">awsLogLevel</div> <div class="operator">=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
+			<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithSigning</div> <div class="operator">|</div>
+			<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithHTTPBody</div> <div class="operator">|</div>
+			<div class="ident">aws</div><div class="operator">.</div><div class="ident">LogDebugWithEventStreamBody</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">awsConf</div> <div class="operator">:=</div> <div class="ident">aws</div><div class="operator">.</div><div class="ident">NewConfig</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div>
+		<div class="ident">WithCredentials</div><div class="operator">(</div><div class="ident">credentials</div><div class="operator">.</div><div class="ident">NewStaticCredentials</div><div class="operator">(</div>
+			<div class="ident">conf</div><div class="operator">.</div><div class="ident">AWSAccessID</div><div class="operator">,</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">AWSSecretKey</div><div class="operator">,</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">AWSSessionToken</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator">)</div><div class="operator">.</div>
+		<div class="ident">WithRegion</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">AWSRegion</div><div class="operator">)</div><div class="operator">.</div>
+		<div class="ident">WithLogLevel</div><div class="operator">(</div><div class="ident">awsLogLevel</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div> <div class="operator">&gt;</div> <div class="literal">0</div> <div class="operator">{</div>
+		<div class="ident">awsConf</div> <div class="operator">=</div> <div class="ident">awsConf</div><div class="operator">.</div><div class="ident">WithEndpoint</div><div class="operator">(</div><div class="ident">AWSCloudWatchEndpoint</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">cloudWatchSession</div> <div class="operator">:=</div> <div class="ident">session</div><div class="operator">.</div><div class="ident">Must</div><div class="operator">(</div><div class="ident">session</div><div class="operator">.</div><div class="ident">NewSession</div><div class="operator">(</div><div class="ident">awsConf</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">CloudWatchClient</div> <div class="operator">:=</div> <div class="ident">cloudwatchlogs</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">cloudWatchSession</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">var</div> <div class="ident">cloudWatchWriter</div> <div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">CreateStreamIfNotExists</div> <div class="operator">{</div>
+		<div class="ident">group</div> <div class="operator">:=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewGroup</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">var</div> <div class="ident">err</div> <div class="ident">error</div><div class="operator"></div>
+		<div class="ident">cloudWatchWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">=</div> <div class="ident">group</div><div class="operator">.</div><div class="ident">Create</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+			<div class="keyword">return</div> <div class="ident">nil</div><div class="operator">,</div> <div class="ident">err</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator"></div>
+	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
+		<div class="ident">cloudWatchWriter</div> <div class="operator">=</div> <div class="ident">cloudwatch</div><div class="operator">.</div><div class="ident">NewWriter</div><div class="operator">(</div>
+			<div class="ident">conf</div><div class="operator">.</div><div class="ident">LogGroup</div><div class="operator">,</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">StreamName</div><div class="operator">,</div> <div class="ident">CloudWatchClient</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">return</div> <div class="ident">cloudWatchWriter</div><div class="operator">,</div> <div class="ident">nil</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">setupSentryLogging</div><div class="operator">(</div><div class="ident">conf</div> <div class="ident">SentryLoggingConfiguration</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">io</div><div class="operator">.</div><div class="ident">WriteCloser</div><div class="operator">,</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">sentryWriter</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">zlogsentry</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">SentryDSN</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+		<div class="keyword">return</div> <div class="ident">nil</div><div class="operator">,</div> <div class="ident">err</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">return</div> <div class="ident">sentryWriter</div><div class="operator">,</div> <div class="ident">nil</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">setupKafkaZerolog</div><div class="operator">(</div><div class="ident">conf</div> <div class="ident">KafkaZerologConfiguration</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">io</div><div class="operator">.</div><div class="ident">WriteCloser</div><div class="operator">,</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="keyword">return</div> <div class="ident">kafkazerolog</div><div class="operator">.</div><div class="ident">NewKafkaLogger</div><div class="operator">(</div><div class="ident">kafkazerolog</div><div class="operator">.</div><div class="ident">KafkaLoggerConf</div><div class="operator">{</div>
+		<div class="ident">Broker</div><div class="operator">:</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">Broker</div><div class="operator">,</div>
+		<div class="ident">Topic</div><div class="operator">:</div>  <div class="ident">conf</div><div class="operator">.</div><div class="ident">Topic</div><div class="operator">,</div>
+		<div class="ident">Cert</div><div class="operator">:</div>   <div class="ident">conf</div><div class="operator">.</div><div class="ident">CertPath</div><div class="operator">,</div>
+		<div class="ident">Level</div><div class="operator">:</div>  <div class="ident">conf</div><div class="operator">.</div><div class="ident">Level</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">const</div> <div class="ident">kafkaErrorPrefix</div> <div class="operator">=</div> <div class="literal">&#34;kafka: error&#34;</div><div class="operator"></div>

--- a/docs/packages/logger/logger_test.html
+++ b/docs/packages/logger/logger_test.html
@@ -163,6 +163,10 @@ limitations under the License.</p>
 		<div class="ident">CreateStreamIfNotExists</div><div class="operator">:</div> <div class="ident">true</div><div class="operator">,</div>
 		<div class="ident">Debug</div><div class="operator">:</div>                   <div class="ident">false</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator"></div>
+	<div class="ident">kafkaLoggingConf</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div>
+		<div class="ident">Broker</div><div class="operator">:</div> <div class="literal">&#34;kafka_broker&#34;</div><div class="operator">,</div>
+		<div class="ident">Topic</div><div class="operator">:</div>  <div class="literal">&#34;topicname&#34;</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator"></div>
 	<div class="ident">describeLogStreamsEvent</div> <div class="operator">=</div> <div class="ident">RemoteLoggingExpect</div><div class="operator">{</div>
 		<div class="ident">http</div><div class="operator">.</div><div class="ident">MethodPost</div><div class="operator">,</div>
 		<div class="literal">&#34;Logs_20140328.DescribeLogStreams&#34;</div><div class="operator">,</div>
@@ -213,9 +217,11 @@ limitations under the License.</p>
 			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">false</div><div class="operator">,</div>
+			<div class="ident">LoggingToKafkaEnabled</div><div class="operator">:</div>      <div class="ident">false</div><div class="operator">,</div>
 		<div class="operator">}</div><div class="operator">,</div>
 		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 		<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">buf</div><div class="operator">)</div><div class="operator">,</div>
 	<div class="operator">)</div><div class="operator"></div>
 	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
@@ -253,6 +259,7 @@ limitations under the License.</p>
 				<div class="operator">}</div><div class="operator">,</div>
 				<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 				<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+				<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 				<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">buf</div><div class="operator">)</div><div class="operator">,</div>
 			<div class="operator">)</div><div class="operator"></div>
 			<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
@@ -314,6 +321,7 @@ limitations under the License.</p>
 		<div class="operator">}</div><div class="operator">,</div>
 		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 		<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
 	<div class="operator">)</div><div class="operator"></div>
 	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
@@ -400,7 +408,11 @@ limitations under the License.</p>
 			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">true</div><div class="operator">,</div>
-		<div class="operator">}</div><div class="operator">,</div> <div class="ident">cloudWatchConf</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">cloudWatchConf</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator"></div>
 		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 
 		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;test message&#34;</div><div class="operator">)</div><div class="operator"></div>
@@ -417,7 +429,11 @@ limitations under the License.</p>
 		<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 		<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
 		<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">true</div><div class="operator">,</div>
-	<div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div> <div class="ident">sentryConf</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">sentryConf</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator"></div>
 	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
@@ -431,20 +447,29 @@ limitations under the License.</p>
 		<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 		<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
 		<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">true</div><div class="operator">,</div>
-	<div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div> <div class="ident">sentryConf</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">LoggingToKafkaEnabled</div><div class="operator">:</div>      <div class="ident">false</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">sentryConf</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator"></div>
 	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloseZerolog</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">func</div> <div class="ident">TestStdoutLog</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
 	<div class="ident">stdOut</div><div class="operator">,</div> <div class="ident">stdErr</div> <div class="operator">:=</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CatchingOutputs</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="operator">)</div> <div class="operator">{</div>
-		<div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+		<div class="ident">_</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
 			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">UseStderr</div><div class="operator">:</div>                  <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">false</div><div class="operator">,</div>
-		<div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator"></div>
 
 		<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Hello world&#34;</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
@@ -455,19 +480,43 @@ limitations under the License.</p>
 
 <div class="keyword">func</div> <div class="ident">TestStderrLog</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
 	<div class="ident">stdOut</div><div class="operator">,</div> <div class="ident">stdErr</div> <div class="operator">:=</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CatchingOutputs</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="operator">)</div> <div class="operator">{</div>
-		<div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+		<div class="ident">_</div> <div class="operator">=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
 			<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">UseStderr</div><div class="operator">:</div>                  <div class="ident">true</div><div class="operator">,</div>
 			<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
 			<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
 			<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">false</div><div class="operator">,</div>
-		<div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+		<div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+			<div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator"></div>
 
 		<div class="ident">log</div><div class="operator">.</div><div class="ident">Info</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Hello world&#34;</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="ident">assert</div><div class="operator">.</div><div class="ident">NotContains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">string</div><div class="operator">(</div><div class="ident">stdOut</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">`&#34;message&#34;:&#34;Hello world&#34;`</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">assert</div><div class="operator">.</div><div class="ident">Contains</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">string</div><div class="operator">(</div><div class="ident">stdErr</div><div class="operator">)</div><div class="operator">,</div> <div class="literal">`&#34;message&#34;:&#34;Hello world&#34;`</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestKafkaLogging</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">kafkaLoggingConf</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">KafkaZerologConfiguration</div><div class="operator">{</div>
+		<div class="ident">Broker</div><div class="operator">:</div> <div class="literal">&#34;kafka:9092&#34;</div><div class="operator">,</div>
+		<div class="ident">Topic</div><div class="operator">:</div>  <div class="literal">&#34;log_topic&#34;</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">logger</div><div class="operator">.</div><div class="ident">InitZerolog</div><div class="operator">(</div><div class="ident">logger</div><div class="operator">.</div><div class="ident">LoggingConfiguration</div><div class="operator">{</div>
+		<div class="ident">Debug</div><div class="operator">:</div>                      <div class="ident">false</div><div class="operator">,</div>
+		<div class="ident">LogLevel</div><div class="operator">:</div>                   <div class="literal">&#34;debug&#34;</div><div class="operator">,</div>
+		<div class="ident">LoggingToCloudWatchEnabled</div><div class="operator">:</div> <div class="ident">false</div><div class="operator">,</div>
+		<div class="ident">LoggingToSentryEnabled</div><div class="operator">:</div>     <div class="ident">false</div><div class="operator">,</div>
+		<div class="ident">LoggingToKafkaEnabled</div><div class="operator">:</div>      <div class="ident">true</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">CloudWatchConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">logger</div><div class="operator">.</div><div class="ident">SentryLoggingConfiguration</div><div class="operator">{</div><div class="operator">}</div><div class="operator">,</div>
+		<div class="ident">kafkaLoggingConf</div><div class="operator">,</div>
+	<div class="operator">)</div><div class="operator"></div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">FailOnError</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">err</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291
 	github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556
+	github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec
 	github.com/Shopify/sarama v1.27.1
 	github.com/archdx/zerolog-sentry v0.0.1
 	github.com/aws/aws-sdk-go v1.35.7

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556 h1:id0piGUdHbHhze/RXSqUjd1mQdnCxqm2WaW32xPsg7k=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
+github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
+github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.26.0/go.mod h1:y/CFFTO9eaMTNriwu/Q+W4eioLqiDMGkA1W+gmdfj8w=
@@ -324,6 +326,7 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
+github.com/klauspost/compress v1.9.8/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.1 h1:bPb7nMRdOZYDrpPMTA3EInUQrdgoBinqUuSwlGdKDdE=
 github.com/klauspost/compress v1.11.1/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
@@ -492,6 +495,8 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/segmentio/kafka-go v0.4.10 h1:YnI820ZLfh710adINqwuCVtN3wbnLsLnT/+xhI0oooQ=
+github.com/segmentio/kafka-go v0.4.10/go.mod h1:BVDwBTF24avtlj4l8/xsWNb4papVeg16+jO6/0qjvhA=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -586,6 +591,7 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/logger/configuration.go
+++ b/logger/configuration.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package logger
 
+import "github.com/rs/zerolog"
+
 // LoggingConfiguration represents configuration for logging in general
 type LoggingConfiguration struct {
 	// Debug enables pretty colored logging
@@ -39,6 +41,10 @@ type LoggingConfiguration struct {
 	// LoggingToSentryEnabled enables logging to Sentry
 	// (configuration for Sentry is in SentryLoggingConfiguration)
 	LoggingToSentryEnabled bool `mapstructure:"logging_to_sentry_enabled" toml:"logging_to_sentry_enabled"`
+
+	// LoggingToKafkaEnabled enables logging to Kafka
+	// (configuration for Kafka logging is in KafkaZerologConfiguration)
+	LoggingToKafkaEnabled bool `mapstructure:"logging_to_kafka_enabled" toml:"logging_to_kafka_enabled"`
 }
 
 // CloudWatchConfiguration represents configuration of CloudWatch logger
@@ -58,4 +64,12 @@ type CloudWatchConfiguration struct {
 // SentryLoggingConfiguration represents the configuration of Sentry logger
 type SentryLoggingConfiguration struct {
 	SentryDSN string `mapstructure:"dsn" toml:"dsn"`
+}
+
+// KafkaZerologConfiguration represetns the configuration for sending log messages to a Kafka topic
+type KafkaZerologConfiguration struct {
+	Broker   string        `mapstructure:"broker" toml:"broker"`
+	Topic    string        `mapstructure:"topic" toml:"topic"`
+	CertPath string        `mapstructure:"cert_path" toml:"cert_path"`
+	Level    zerolog.Level `mapstructure:"level" toml:"level"`
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -379,3 +379,23 @@ func TestStderrLog(t *testing.T) {
 	assert.NotContains(t, string(stdOut), `"message":"Hello world"`)
 	assert.Contains(t, string(stdErr), `"message":"Hello world"`)
 }
+
+func TestKafkaLogging(t *testing.T) {
+	kafkaLoggingConf := logger.KafkaZerologConfiguration{
+		Broker: "kafka:9092",
+		Topic:  "log_topic",
+	}
+
+	err := logger.InitZerolog(logger.LoggingConfiguration{
+		Debug:                      false,
+		LogLevel:                   "debug",
+		LoggingToCloudWatchEnabled: false,
+		LoggingToSentryEnabled:     false,
+		LoggingToKafkaEnabled:      true,
+	},
+		logger.CloudWatchConfiguration{},
+		logger.SentryLoggingConfiguration{},
+		kafkaLoggingConf,
+	)
+	helpers.FailOnError(t, err)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -44,6 +44,10 @@ var (
 		CreateStreamIfNotExists: true,
 		Debug:                   false,
 	}
+	kafkaLoggingConf = logger.KafkaZerologConfiguration{
+		Broker: "kafka_broker",
+		Topic:  "topicname",
+	}
 	describeLogStreamsEvent = RemoteLoggingExpect{
 		http.MethodPost,
 		"Logs_20140328.DescribeLogStreams",
@@ -94,9 +98,11 @@ func TestSaramaZerologger(t *testing.T) {
 			LogLevel:                   "debug",
 			LoggingToCloudWatchEnabled: false,
 			LoggingToSentryEnabled:     false,
+			LoggingToKafkaEnabled:      false,
 		},
 		logger.CloudWatchConfiguration{},
 		logger.SentryLoggingConfiguration{},
+		logger.KafkaZerologConfiguration{},
 		zerolog.New(buf),
 	)
 	helpers.FailOnError(t, err)
@@ -134,6 +140,7 @@ func TestLoggerSetLogLevel(t *testing.T) {
 				},
 				logger.CloudWatchConfiguration{},
 				logger.SentryLoggingConfiguration{},
+				logger.KafkaZerologConfiguration{},
 				zerolog.New(buf),
 			)
 			helpers.FailOnError(t, err)
@@ -195,6 +202,7 @@ func TestInitZerolog_LogToCloudWatch(t *testing.T) {
 		},
 		logger.CloudWatchConfiguration{},
 		logger.SentryLoggingConfiguration{},
+		logger.KafkaZerologConfiguration{},
 	)
 	helpers.FailOnError(t, err)
 }
@@ -281,7 +289,11 @@ func TestLoggingToCloudwatch(t *testing.T) {
 			Debug:                      false,
 			LogLevel:                   "debug",
 			LoggingToCloudWatchEnabled: true,
-		}, cloudWatchConf, logger.SentryLoggingConfiguration{})
+		},
+			cloudWatchConf,
+			logger.SentryLoggingConfiguration{},
+			logger.KafkaZerologConfiguration{},
+		)
 		helpers.FailOnError(t, err)
 
 		log.Error().Msg("test message")
@@ -298,7 +310,11 @@ func TestInitZerolog_LogToSentry(t *testing.T) {
 		LogLevel:                   "debug",
 		LoggingToCloudWatchEnabled: false,
 		LoggingToSentryEnabled:     true,
-	}, logger.CloudWatchConfiguration{}, sentryConf)
+	},
+		logger.CloudWatchConfiguration{},
+		sentryConf,
+		logger.KafkaZerologConfiguration{},
+	)
 	helpers.FailOnError(t, err)
 }
 
@@ -312,7 +328,12 @@ func TestCloseZerolog(t *testing.T) {
 		LogLevel:                   "debug",
 		LoggingToCloudWatchEnabled: false,
 		LoggingToSentryEnabled:     true,
-	}, logger.CloudWatchConfiguration{}, sentryConf)
+		LoggingToKafkaEnabled:      false,
+	},
+		logger.CloudWatchConfiguration{},
+		sentryConf,
+		logger.KafkaZerologConfiguration{},
+	)
 	helpers.FailOnError(t, err)
 	logger.CloseZerolog()
 }
@@ -325,7 +346,11 @@ func TestStdoutLog(t *testing.T) {
 			LogLevel:                   "debug",
 			LoggingToCloudWatchEnabled: false,
 			LoggingToSentryEnabled:     false,
-		}, logger.CloudWatchConfiguration{}, logger.SentryLoggingConfiguration{})
+		},
+			logger.CloudWatchConfiguration{},
+			logger.SentryLoggingConfiguration{},
+			logger.KafkaZerologConfiguration{},
+		)
 
 		log.Info().Msg("Hello world")
 	})
@@ -342,7 +367,11 @@ func TestStderrLog(t *testing.T) {
 			LogLevel:                   "debug",
 			LoggingToCloudWatchEnabled: false,
 			LoggingToSentryEnabled:     false,
-		}, logger.CloudWatchConfiguration{}, logger.SentryLoggingConfiguration{})
+		},
+			logger.CloudWatchConfiguration{},
+			logger.SentryLoggingConfiguration{},
+			logger.KafkaZerologConfiguration{},
+		)
 
 		log.Info().Msg("Hello world")
 	})


### PR DESCRIPTION
# Description

Adds support for using `kafkazerolog` writer in order to send log messages directly to a Kafka topic. Supports Kafka over SSL

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Regular CI