### PR TITLE
Bump Golang version for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 
 language: go
 go:
-- 1.13
+- 1.14
 
 jobs:
   include:


### PR DESCRIPTION
# Description

Bump Go version to 1.14 in the CI configuration

## Type of change
- Refactor (refactoring code, removing useless files)

## Testing steps

Regular CI