### PR TITLE
Relax condition type to parse string and list of strings

### DIFF
--- a/types/content.go
+++ b/types/content.go
@@ -31,13 +31,13 @@ type RuleErrorKeyContent struct {
 // ErrorKeyMetadata is a Go representation of the `metadata.yaml`
 // file inside of an error key content directory.
 type ErrorKeyMetadata struct {
-	Condition   string   `yaml:"condition" json:"condition"`
-	Description string   `yaml:"description" json:"description"`
-	Impact      string   `yaml:"impact" json:"impact"`
-	Likelihood  int      `yaml:"likelihood" json:"likelihood"`
-	PublishDate string   `yaml:"publish_date" json:"publish_date"`
-	Status      string   `yaml:"status" json:"status"`
-	Tags        []string `yaml:"tags" json:"tags"`
+	Condition   interface{} `yaml:"condition" json:"condition"`
+	Description string      `yaml:"description" json:"description"`
+	Impact      string      `yaml:"impact" json:"impact"`
+	Likelihood  int         `yaml:"likelihood" json:"likelihood"`
+	PublishDate string      `yaml:"publish_date" json:"publish_date"`
+	Status      string      `yaml:"status" json:"status"`
+	Tags        []string    `yaml:"tags" json:"tags"`
 }
 
 // RuleContentDirectory contains content for all available rules in a directory.


### PR DESCRIPTION
# Description

As a temporary fix for #183, the ErrorKeyMetadata struct will allow any type of value in "Condition" item.
The rules parser in insights-content-service will verify that the parsed value is either a string or a list of strings.
This allows us to provide the new rules (that are currently ignored) while keeping the previously working ones intact.

Fixes #183

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Locally imported into insights-content-service and tested the parser. 