### PR TITLE
Configure the log level using an string instead of integer

### DIFF
--- a/docs/packages/logger/configuration.html
+++ b/docs/packages/logger/configuration.html
@@ -135,8 +135,6 @@ limitations under the License.
 
 <div class="keyword">package</div> <div class="ident">logger</div><div class="operator"></div>
 
-<div class="keyword">import</div> <div class="literal">&#34;github.com/rs/zerolog&#34;</div><div class="operator"></div>
-
 </code></pre></td>
       </tr>
       
@@ -237,10 +235,10 @@ limitations under the License.
 	<td class="doc"><p>KafkaZerologConfiguration represetns the configuration for sending log messages to a Kafka topic</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">KafkaZerologConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
-	<div class="ident">Broker</div>   <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;broker&#34; toml:&#34;broker&#34;`</div><div class="operator"></div>
-	<div class="ident">Topic</div>    <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;topic&#34; toml:&#34;topic&#34;`</div><div class="operator"></div>
-	<div class="ident">CertPath</div> <div class="ident">string</div>        <div class="literal">`mapstructure:&#34;cert_path&#34; toml:&#34;cert_path&#34;`</div><div class="operator"></div>
-	<div class="ident">Level</div>    <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">Level</div> <div class="literal">`mapstructure:&#34;level&#34; toml:&#34;level&#34;`</div><div class="operator"></div>
+	<div class="ident">Broker</div>   <div class="ident">string</div> <div class="literal">`mapstructure:&#34;broker&#34; toml:&#34;broker&#34;`</div><div class="operator"></div>
+	<div class="ident">Topic</div>    <div class="ident">string</div> <div class="literal">`mapstructure:&#34;topic&#34; toml:&#34;topic&#34;`</div><div class="operator"></div>
+	<div class="ident">CertPath</div> <div class="ident">string</div> <div class="literal">`mapstructure:&#34;cert_path&#34; toml:&#34;cert_path&#34;`</div><div class="operator"></div>
+	<div class="ident">Level</div>    <div class="ident">string</div> <div class="literal">`mapstructure:&#34;level&#34; toml:&#34;level&#34;`</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/docs/packages/logger/logger.html
+++ b/docs/packages/logger/logger.html
@@ -317,20 +317,26 @@ TODO: delete when RHIOPS-729 is fixed</p>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">func</div> <div class="ident">setGlobalLogLevel</div><div class="operator">(</div><div class="ident">configuration</div> <div class="ident">LoggingConfiguration</div><div class="operator">)</div> <div class="operator">{</div>
-	<div class="ident">logLevel</div> <div class="operator">:=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ToLower</div><div class="operator">(</div><div class="ident">strings</div><div class="operator">.</div><div class="ident">TrimSpace</div><div class="operator">(</div><div class="ident">configuration</div><div class="operator">.</div><div class="ident">LogLevel</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">logLevel</div> <div class="operator">:=</div> <div class="ident">convertLogLevel</div><div class="operator">(</div><div class="ident">configuration</div><div class="operator">.</div><div class="ident">LogLevel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">logLevel</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
 
-	<div class="keyword">switch</div> <div class="ident">logLevel</div> <div class="operator">{</div>
+<div class="keyword">func</div> <div class="ident">convertLogLevel</div><div class="operator">(</div><div class="ident">level</div> <div class="ident">string</div><div class="operator">)</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">Level</div> <div class="operator">{</div>
+	<div class="ident">level</div> <div class="operator">=</div> <div class="ident">strings</div><div class="operator">.</div><div class="ident">ToLower</div><div class="operator">(</div><div class="ident">strings</div><div class="operator">.</div><div class="ident">TrimSpace</div><div class="operator">(</div><div class="ident">level</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">switch</div> <div class="ident">level</div> <div class="operator">{</div>
 	<div class="keyword">case</div> <div class="literal">&#34;debug&#34;</div><div class="operator">:</div>
-		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">DebugLevel</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">DebugLevel</div><div class="operator"></div>
 	<div class="keyword">case</div> <div class="literal">&#34;info&#34;</div><div class="operator">:</div>
-		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">InfoLevel</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">InfoLevel</div><div class="operator"></div>
 	<div class="keyword">case</div> <div class="literal">&#34;warn&#34;</div><div class="operator">,</div> <div class="literal">&#34;warning&#34;</div><div class="operator">:</div>
-		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">WarnLevel</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">WarnLevel</div><div class="operator"></div>
 	<div class="keyword">case</div> <div class="literal">&#34;error&#34;</div><div class="operator">:</div>
-		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ErrorLevel</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">ErrorLevel</div><div class="operator"></div>
 	<div class="keyword">case</div> <div class="literal">&#34;fatal&#34;</div><div class="operator">:</div>
-		<div class="ident">zerolog</div><div class="operator">.</div><div class="ident">SetGlobalLevel</div><div class="operator">(</div><div class="ident">zerolog</div><div class="operator">.</div><div class="ident">FatalLevel</div><div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">FatalLevel</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">return</div> <div class="ident">zerolog</div><div class="operator">.</div><div class="ident">DebugLevel</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 <div class="keyword">func</div> <div class="ident">setupCloudwatchLogging</div><div class="operator">(</div><div class="ident">conf</div> <div class="ident">CloudWatchConfiguration</div><div class="operator">)</div> <div class="operator">(</div><div class="ident">io</div><div class="operator">.</div><div class="ident">Writer</div><div class="operator">,</div> <div class="ident">error</div><div class="operator">)</div> <div class="operator">{</div>
@@ -389,7 +395,7 @@ TODO: delete when RHIOPS-729 is fixed</p>
 		<div class="ident">Broker</div><div class="operator">:</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">Broker</div><div class="operator">,</div>
 		<div class="ident">Topic</div><div class="operator">:</div>  <div class="ident">conf</div><div class="operator">.</div><div class="ident">Topic</div><div class="operator">,</div>
 		<div class="ident">Cert</div><div class="operator">:</div>   <div class="ident">conf</div><div class="operator">.</div><div class="ident">CertPath</div><div class="operator">,</div>
-		<div class="ident">Level</div><div class="operator">:</div>  <div class="ident">conf</div><div class="operator">.</div><div class="ident">Level</div><div class="operator">,</div>
+		<div class="ident">Level</div><div class="operator">:</div>  <div class="ident">convertLogLevel</div><div class="operator">(</div><div class="ident">conf</div><div class="operator">.</div><div class="ident">Level</div><div class="operator">)</div><div class="operator">,</div>
 	<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 

--- a/logger/configuration.go
+++ b/logger/configuration.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package logger
 
-import "github.com/rs/zerolog"
-
 // LoggingConfiguration represents configuration for logging in general
 type LoggingConfiguration struct {
 	// Debug enables pretty colored logging
@@ -68,8 +66,8 @@ type SentryLoggingConfiguration struct {
 
 // KafkaZerologConfiguration represetns the configuration for sending log messages to a Kafka topic
 type KafkaZerologConfiguration struct {
-	Broker   string        `mapstructure:"broker" toml:"broker"`
-	Topic    string        `mapstructure:"topic" toml:"topic"`
-	CertPath string        `mapstructure:"cert_path" toml:"cert_path"`
-	Level    zerolog.Level `mapstructure:"level" toml:"level"`
+	Broker   string `mapstructure:"broker" toml:"broker"`
+	Topic    string `mapstructure:"topic" toml:"topic"`
+	CertPath string `mapstructure:"cert_path" toml:"cert_path"`
+	Level    string `mapstructure:"level" toml:"level"`
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -153,20 +153,26 @@ func CloseZerolog() {
 }
 
 func setGlobalLogLevel(configuration LoggingConfiguration) {
-	logLevel := strings.ToLower(strings.TrimSpace(configuration.LogLevel))
+	logLevel := convertLogLevel(configuration.LogLevel)
+	zerolog.SetGlobalLevel(logLevel)
+}
 
-	switch logLevel {
+func convertLogLevel(level string) zerolog.Level {
+	level = strings.ToLower(strings.TrimSpace(level))
+	switch level {
 	case "debug":
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		return zerolog.DebugLevel
 	case "info":
-		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		return zerolog.InfoLevel
 	case "warn", "warning":
-		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		return zerolog.WarnLevel
 	case "error":
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		return zerolog.ErrorLevel
 	case "fatal":
-		zerolog.SetGlobalLevel(zerolog.FatalLevel)
+		return zerolog.FatalLevel
 	}
+
+	return zerolog.DebugLevel
 }
 
 func setupCloudwatchLogging(conf CloudWatchConfiguration) (io.Writer, error) {
@@ -225,7 +231,7 @@ func setupKafkaZerolog(conf KafkaZerologConfiguration) (io.WriteCloser, error) {
 		Broker: conf.Broker,
 		Topic:  conf.Topic,
 		Cert:   conf.CertPath,
-		Level:  conf.Level,
+		Level:  convertLogLevel(conf.Level),
 	})
 }
 


### PR DESCRIPTION
# Description

Update configuration for Kafka logging to allow use an string instead of integers

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update

## Testing steps

Regular CI