### PR TITLE
Move RuleRating struct from aggregator to utils in order to be used by several projects

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -303,3 +303,9 @@ type SystemWideRuleDisable struct {
 	CreatedAt     sql.NullTime `json:"created_at"`
 	UpdatedAT     sql.NullTime `json:"updated_at"`
 }
+
+// RuleRating represents the body request of request to the rating endpoint
+type RuleRating struct {
+	Rule   string   `json:"rule"`
+	Rating UserVote `json:"rating"`
+}


### PR DESCRIPTION
# Description

Tule `RuleRating` struct will be used by Aggregator and Smart Proxy, so it needs its place in the types package

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Regular CI