### PR TITLE
Mock NewTLSConfig tests so we can reach a 100% coverage

### DIFF
--- a/tls/tls_config.go
+++ b/tls/tls_config.go
@@ -8,9 +8,29 @@ import (
 	"path/filepath"
 )
 
+type tlsConfigGetter interface {
+	newCertPoolGetter() *x509.CertPool
+	appendCertsFromPEMGetter(caCertPool *x509.CertPool, pemCerts []byte) (ok bool)
+}
+
+type tlsConfigX509Getter struct{}
+
 // NewTLSConfig create a TLS configuration from a certificate path. This can be
 // used with Sarama for example.
 func NewTLSConfig(certPath string) (*tls.Config, error) {
+	tcg := new(tlsConfigX509Getter)
+	return newTLSConfig(tcg, certPath)
+}
+
+func (t tlsConfigX509Getter) newCertPoolGetter() *x509.CertPool {
+	return x509.NewCertPool()
+}
+
+func (t tlsConfigX509Getter) appendCertsFromPEMGetter(caCertPool *x509.CertPool, pemCerts []byte) (ok bool) {
+	return caCertPool.AppendCertsFromPEM(pemCerts)
+}
+
+func newTLSConfig(t tlsConfigGetter, certPath string) (*tls.Config, error) {
 	if certPath == "" {
 		return nil, fmt.Errorf("no cert path provided. Skip")
 	}
@@ -24,12 +44,12 @@ func NewTLSConfig(certPath string) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	caCertPool := x509.NewCertPool()
-	if caCert == nil {
+	caCertPool := t.newCertPoolGetter()
+	if caCertPool == nil {
 		return nil, fmt.Errorf("pointer to new CertPool is nil")
 	}
 
-	ok := caCertPool.AppendCertsFromPEM(caCert)
+	ok := t.appendCertsFromPEMGetter(caCertPool, caCert)
 	if !ok {
 		return nil, fmt.Errorf("error appending the specified certificate")
 	}

--- a/tls/tls_config_inter_test.go
+++ b/tls/tls_config_inter_test.go
@@ -1,0 +1,41 @@
+package tlsutil
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewTLSConfig tests the NewTLSConfig method
+func TestNewTLSConfigWithMock(t *testing.T) {
+	var certPath = "../testdata/cert.pem"
+	t.Run("bad x509.CertPool", func(t *testing.T) {
+		_, err := newTLSConfig(tlsConfigX509GetterWithNilInNewCertPoolGetter{}, certPath)
+		assert.Error(t, err)
+	})
+	t.Run("bad appendCertsFromPEMGetter", func(t *testing.T) {
+		_, err := newTLSConfig(tlsConfigX509GetterWithFalseInAppendCertsFromPEMGetter{}, certPath)
+		assert.Error(t, err)
+	})
+}
+
+type tlsConfigX509GetterWithNilInNewCertPoolGetter struct{}
+
+func (t tlsConfigX509GetterWithNilInNewCertPoolGetter) newCertPoolGetter() *x509.CertPool {
+	return nil
+}
+
+func (t tlsConfigX509GetterWithNilInNewCertPoolGetter) appendCertsFromPEMGetter(caCertPool *x509.CertPool, pemCerts []byte) (ok bool) {
+	return caCertPool.AppendCertsFromPEM(pemCerts)
+}
+
+type tlsConfigX509GetterWithFalseInAppendCertsFromPEMGetter struct{}
+
+func (t tlsConfigX509GetterWithFalseInAppendCertsFromPEMGetter) newCertPoolGetter() *x509.CertPool {
+	return x509.NewCertPool()
+}
+
+func (t tlsConfigX509GetterWithFalseInAppendCertsFromPEMGetter) appendCertsFromPEMGetter(caCertPool *x509.CertPool, pemCerts []byte) (ok bool) {
+	return false
+}


### PR DESCRIPTION
# Description

I mocked the NewTLSConfig function so we can test all its parts. I also discovered a bug because I was checking `caCert` instead of `caCertPool` not to be `nil`.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

`go test`.
