### PR TITLE
Add router_utils method to retrieve RuleSelector from query parameters

### DIFF
--- a/http/router_utils.go
+++ b/http/router_utils.go
@@ -149,23 +149,23 @@ func ReadErrorKey(writer http.ResponseWriter, request *http.Request) (types.Erro
 func ReadRuleSelector(writer http.ResponseWriter, request *http.Request) (types.RuleSelector, bool) {
 	ruleSelector, err := GetRouterParam(request, "rule_id")
 	if err != nil {
-		const message = "unable to get rule FQDN"
+		const message = "unable to get rule selector from rule_id parameter"
 		log.Error().Err(err).Msg(message)
 		types.HandleServerError(writer, err)
-		return "0", false
+		return "", false
 	}
 
 	isRuleSelectorValid := RuleSelectorValidator.Match([]byte(ruleSelector))
 
 	if !isRuleSelectorValid {
-		errMsg := "Param rule_id is not a valid rule FQDN"
+		errMsg := "Param rule_id is not a valid rule selector (plugin_name|error_key)"
 		log.Error().Msg(errMsg)
 		types.HandleServerError(writer, &types.RouterParsingError{
 			ParamName:  "rule_id",
 			ParamValue: ruleSelector,
 			ErrString:  errMsg,
 		})
-		return "0", false
+		return "", false
 	}
 
 	return types.RuleSelector(ruleSelector), true

--- a/http/router_utils_test.go
+++ b/http/router_utils_test.go
@@ -210,7 +210,7 @@ func TestReadErrorKey_Error(t *testing.T) {
 	)
 }
 
-func TestReadRuleFQDN_Error(t *testing.T) {
+func TestReadRuleSelector_Error(t *testing.T) {
 	for _, testCase := range []struct {
 		TestCaseName  string
 		Args          map[string]string
@@ -218,35 +218,35 @@ func TestReadRuleFQDN_Error(t *testing.T) {
 	}{
 		{TestCaseName: "Missing", Args: nil, ExpectedError: `{"status":"Missing required param from request: rule_id"}`},
 		{
-			TestCaseName: "BadRuleFQDN",
+			TestCaseName: "BadRuleSelector",
 			Args: map[string]string{
 				"rule_id": string(testdata.BadRuleID),
 			},
 			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
 				string(testdata.BadRuleID) +
-				`'. Error: 'Param rule_id is not a valid rule FQDN'"}`,
+				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 		{
-			TestCaseName: "RuleComponentAsRuleFQDN",
+			TestCaseName: "RuleComponentAsRuleSelector",
 			Args: map[string]string{
 				"rule_id": string(testdata.Rule1ID),
 			},
 			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
 				string(testdata.Rule1ID) +
-				`'. Error: 'Param rule_id is not a valid rule FQDN'"}`,
+				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 		{
-			TestCaseName: "RuleComponentAsRuleFQDN",
+			TestCaseName: "RuleComponentAsRuleSelector",
 			Args: map[string]string{
 				"rule_id": string(testdata.Rule1ID + "|"),
 			},
 			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
 				string(testdata.Rule1ID+"|") +
-				`'. Error: 'Param rule_id is not a valid rule FQDN'"}`,
+				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 	} {
 		t.Run(testCase.TestCaseName, func(t *testing.T) {
-			testReadParamError(t, "rule_fqdn", testCase.Args, testCase.ExpectedError)
+			testReadParamError(t, "rule_selector", testCase.Args, testCase.ExpectedError)
 		})
 	}
 }
@@ -363,7 +363,7 @@ func testReadParamError(t *testing.T, paramName string, args map[string]string, 
 		_, successful = httputils.ReadOrganizationIDs(recorder, request)
 	case "clusters":
 		_, successful = httputils.ReadClusterNames(recorder, request)
-	case "rule_fqdn":
+	case "rule_selector":
 		_, successful = httputils.ReadRuleSelector(recorder, request)
 	default:
 		panic("testReadParamError is not implemented for param '" + paramName + "'")


### PR DESCRIPTION
# Description

 + Add router_utils::ReadRuleSelector function to retrieve RuleSelector from query parameters
 + Small refactor to only compile regex validators only once

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

New UTs