### PR TITLE
Add types for list of cluster where a rule is currently hitting + refactor ReadRuleSelector

### DIFF
--- a/http/router_utils.go
+++ b/http/router_utils.go
@@ -147,9 +147,9 @@ func ReadErrorKey(writer http.ResponseWriter, request *http.Request) (types.Erro
 // url or writes an error to writer.
 // The function returns the selector and a bool indicating if it was successful.
 func ReadRuleSelector(writer http.ResponseWriter, request *http.Request) (types.RuleSelector, bool) {
-	ruleSelector, err := GetRouterParam(request, "rule_id")
+	ruleSelector, err := GetRouterParam(request, "rule_selector")
 	if err != nil {
-		const message = "unable to get rule selector from rule_id parameter"
+		const message = "Unable to get rule selector from request"
 		log.Error().Err(err).Msg(message)
 		types.HandleServerError(writer, err)
 		return "", false
@@ -158,10 +158,10 @@ func ReadRuleSelector(writer http.ResponseWriter, request *http.Request) (types.
 	isRuleSelectorValid := RuleSelectorValidator.Match([]byte(ruleSelector))
 
 	if !isRuleSelectorValid {
-		errMsg := "Param rule_id is not a valid rule selector (plugin_name|error_key)"
+		errMsg := "Param rule_selector is not a valid rule selector (plugin_name|error_key)"
 		log.Error().Msg(errMsg)
 		types.HandleServerError(writer, &types.RouterParsingError{
-			ParamName:  "rule_id",
+			ParamName:  "rule_selector",
 			ParamValue: ruleSelector,
 			ErrString:  errMsg,
 		})

--- a/http/router_utils_test.go
+++ b/http/router_utils_test.go
@@ -109,7 +109,7 @@ func TestReadParam(t *testing.T) {
 			ParamName:  "organizations",
 			ParamValue: []interface{}{testdata.OrgID, testdata.OrgID},
 		},
-		{TestName: "rule_fqdn", ParamName: "rule_id", ParamValue: []interface{}{testdata.Rule1ID + "|" + testdata.ErrorKey1}},
+		{TestName: "rule_fqdn", ParamName: "rule_selector", ParamValue: []interface{}{testdata.Rule1ID + "|" + testdata.ErrorKey1}},
 	} {
 		expectedParamValue := paramsToString(",", testCase.ParamValue...)
 
@@ -216,33 +216,33 @@ func TestReadRuleSelector_Error(t *testing.T) {
 		Args          map[string]string
 		ExpectedError string
 	}{
-		{TestCaseName: "Missing", Args: nil, ExpectedError: `{"status":"Missing required param from request: rule_id"}`},
+		{TestCaseName: "Missing", Args: nil, ExpectedError: `{"status":"Missing required param from request: rule_selector"}`},
 		{
 			TestCaseName: "BadRuleSelector",
 			Args: map[string]string{
-				"rule_id": string(testdata.BadRuleID),
+				"rule_selector": string(testdata.BadRuleID),
 			},
-			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
+			ExpectedError: `{"status":"Error during parsing param 'rule_selector' with value '` +
 				string(testdata.BadRuleID) +
-				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
+				`'. Error: 'Param rule_selector is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 		{
 			TestCaseName: "RuleComponentAsRuleSelector",
 			Args: map[string]string{
-				"rule_id": string(testdata.Rule1ID),
+				"rule_selector": string(testdata.Rule1ID),
 			},
-			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
+			ExpectedError: `{"status":"Error during parsing param 'rule_selector' with value '` +
 				string(testdata.Rule1ID) +
-				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
+				`'. Error: 'Param rule_selector is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 		{
 			TestCaseName: "RuleComponentAsRuleSelector",
 			Args: map[string]string{
-				"rule_id": string(testdata.Rule1ID + "|"),
+				"rule_selector": string(testdata.Rule1ID + "|"),
 			},
-			ExpectedError: `{"status":"Error during parsing param 'rule_id' with value '` +
+			ExpectedError: `{"status":"Error during parsing param 'rule_selector' with value '` +
 				string(testdata.Rule1ID+"|") +
-				`'. Error: 'Param rule_id is not a valid rule selector (plugin_name|error_key)'"}`,
+				`'. Error: 'Param rule_selector is not a valid rule selector (plugin_name|error_key)'"}`,
 		},
 	} {
 		t.Run(testCase.TestCaseName, func(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -233,17 +233,18 @@ type ClusterReports struct {
 
 // HittingClustersMetadata used to store metadata of clusters hit by a concrete rule
 type HittingClustersMetadata struct {
-	Count       int       `json:"count"`
-	Component   Component `json:"component"`
-	ErrorKey    ErrorKey  `json:"error_key"`
+	Count     int       `json:"count"`
+	Component Component `json:"component"`
+	ErrorKey  ErrorKey  `json:"error_key"`
 }
 
 // HittingClustersData used to store data of clusters hit by a concrete rule
 type HittingClustersData struct {
-	Cluster  ClusterName `json:"cluster"`
-	//Version  string      `json:"version"`
-	GeneratedAt string   `json:"generated_at"`
+	Cluster ClusterName `json:"cluster"`
+	//GeneratedAt string      `json:"generated_at"`
+	//Version     string      `json:"version"`
 }
+
 // HittingClusters is a data structure containing list of clusters hit by a concrete rule
 // hitting the given rule.
 type HittingClusters struct {


### PR DESCRIPTION
# Description

The HittingClusters is to be used in the "rules/{rule_selector}/clusters_detail" endpoint's response.

- HittingClusters struct encloses a list of clusters with timestamp of when they were added to the recommendation table (and in the future, the cluster's version), as well as the accompanying metadata
- HittingClustersMetadata contains the rule selector's data as well as the number of items in the ClusterList object.

Also, ReadRuleSelector has been refactored to expect a 'rule_selector' parameter, which makes more sense

## Type of change

- New feature (non-breaking change which adds functionality)
- Refactor

## Testing steps

CI