### PR TITLE
Use `rule_id` in returned JSON instead of `rule_selector`

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -234,7 +234,7 @@ type ClusterReports struct {
 // HittingClustersMetadata used to store metadata of clusters hit by a concrete rule
 type HittingClustersMetadata struct {
 	Count    int          `json:"count"`
-	Selector RuleSelector `json:"rule_selector"`
+	Selector RuleSelector `json:"rule_id"`
 }
 
 // HittingClustersData used to store data of clusters hit by a concrete rule


### PR DESCRIPTION
# Description

Keep current `rule_id` name in response sent to aggregator and smart_proxy clients instead of `rule_selector`.
- The `rule_selector` type will only be used internally for now, until we can refactor it all.
- This change only affects `/rule/{rule_selector}/clusters_detail` endpoint.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Tested with local aggregator calls