### PR TITLE
[Logging] Use sentry environment

### DIFF
--- a/logger/configuration.go
+++ b/logger/configuration.go
@@ -64,7 +64,8 @@ type CloudWatchConfiguration struct {
 
 // SentryLoggingConfiguration represents the configuration of Sentry logger
 type SentryLoggingConfiguration struct {
-	SentryDSN string `mapstructure:"dsn" toml:"dsn"`
+	SentryDSN         string `mapstructure:"dsn" toml:"dsn"`
+	SentryEnvironment string `mapstructure:"environment" toml:"environment"`
 }
 
 // KafkaZerologConfiguration represetns the configuration for sending log messages to a Kafka topic

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -221,7 +221,7 @@ func setupCloudwatchLogging(conf CloudWatchConfiguration) (io.Writer, error) {
 }
 
 func setupSentryLogging(conf SentryLoggingConfiguration) (io.WriteCloser, error) {
-	sentryWriter, err := zlogsentry.New(conf.SentryDSN)
+	sentryWriter, err := zlogsentry.New(conf.SentryDSN, zlogsentry.WithEnvironment(conf.SentryEnvironment))
 	if err != nil {
 		return nil, err
 	}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -305,7 +305,8 @@ func TestLoggingToCloudwatch(t *testing.T) {
 
 func TestInitZerolog_LogToSentry(t *testing.T) {
 	sentryConf := logger.SentryLoggingConfiguration{
-		SentryDSN: "http://hash@localhost:9999/project/1",
+		SentryDSN:         "http://hash@localhost:9999/project/1",
+		SentryEnvironment: "test_environment",
 	}
 
 	err := logger.InitZerolog(logger.LoggingConfiguration{
@@ -323,7 +324,8 @@ func TestInitZerolog_LogToSentry(t *testing.T) {
 
 func TestCloseZerolog(t *testing.T) {
 	sentryConf := logger.SentryLoggingConfiguration{
-		SentryDSN: "http://hash@localhost:9999/project/1",
+		SentryDSN:         "http://hash@localhost:9999/project/1",
+		SentryEnvironment: "test_environment",
 	}
 
 	err := logger.InitZerolog(logger.LoggingConfiguration{


### PR DESCRIPTION
# Description

This change let us use Sentry environment. You can check [WithEnvironment](https://github.com/archdx/zerolog-sentry/blob/master/writer.go#L177) to understand how this work.

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps

`make test`
