### PR TITLE
Fix typo in s3 lister

### DIFF
--- a/s3/lister.go
+++ b/s3/lister.go
@@ -71,7 +71,7 @@ func listWithDelimiter(client s3iface.S3API, bucket, prefix, lastKey, delimiter 
 
 	if isTruncated {
 		lastKey = output[len(output)-1]
-		newOutput, err := ListBucket(client, bucket, prefix, lastKey, maxKeys)
+		newOutput, err := listWithDelimiter(client, bucket, prefix, lastKey, delimiter, maxKeys)
 		if err != nil {
 			return []string{}, err
 		}


### PR DESCRIPTION
# Description

Found a typo. I was calling `ListBucket` function instead of `listWithDelimiter`. I found it when listing a folder with more than `maxKeys` subfolders.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
