### PR TITLE
Expect .report in rule_selector param (v2 endpoints)

### DIFF
--- a/http/router_utils.go
+++ b/http/router_utils.go
@@ -172,6 +172,17 @@ func ReadRuleSelector(writer http.ResponseWriter, request *http.Request) (ctypes
 	return ctypes.RuleSelector(ruleSelector), true
 }
 
+// ReadAndTrimRuleSelector retrieves the rule selector (rule_id|error_key) from request's
+// url or writes an error to writer.
+// The function returns the selector WITHOUT '.report' and a bool indicating if retrieval was successful.
+func ReadAndTrimRuleSelector(writer http.ResponseWriter, request *http.Request) (ctypes.RuleSelector, bool) {
+	selector, success := ReadRuleSelector(writer, request)
+	if !success {
+		return "", false
+	}
+	return ctypes.RuleSelector(strings.ReplaceAll(string(selector), ".report|", "|")), success
+}
+
 // ReadOrganizationID retrieves organization id from request
 // if it's not possible, it writes http error to the writer and returns false
 func ReadOrganizationID(writer http.ResponseWriter, request *http.Request, auth bool) (ctypes.OrgID, bool) {

--- a/http/router_utils_test.go
+++ b/http/router_utils_test.go
@@ -394,6 +394,7 @@ func mustGetRequestWithMuxVars(
 	return request
 }
 
+//gocyclo:ignore
 func testReadParamError(t *testing.T, paramName string, args map[string]string, expectedError string) {
 	request := mustGetRequestWithMuxVars(t, http.MethodGet, "", nil, args)
 

--- a/http/router_utils_test.go
+++ b/http/router_utils_test.go
@@ -304,6 +304,7 @@ func TestReadRuleSelector_Error(t *testing.T) {
 	} {
 		t.Run(testCase.TestCaseName, func(t *testing.T) {
 			testReadParamError(t, "rule_selector", testCase.Args, testCase.ExpectedError)
+			testReadParamError(t, "rule_selector_trimmed", testCase.Args, testCase.ExpectedError)
 		})
 	}
 }
@@ -424,6 +425,8 @@ func testReadParamError(t *testing.T, paramName string, args map[string]string, 
 		_, successful = httputils.ReadClusterNames(recorder, request)
 	case "rule_selector":
 		_, successful = httputils.ReadRuleSelector(recorder, request)
+	case "rule_selector_trimmed":
+		_, successful = httputils.ReadAndTrimRuleSelector(recorder, request)
 	default:
 		panic("testReadParamError is not implemented for param '" + paramName + "'")
 	}


### PR DESCRIPTION
# Description

The UI will now include ".report" in the `rule_selector`parameter as is done with v1 endpoints. This will simplify queries associated with the recommendations found in the reports. In our v2 endpoints, we need to trim the `.report` in most of our endpoints.

Fixes [CCXDEV-7183](https://issues.redhat.com/browse/CCXDEV-7183)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

- Added corresponding UTs
- Tested the function locally with aggregator and smart-proxy's affected endpoints

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
