### PR TITLE
Use `strings.EqualFold` for string comparison ignoring case

### DIFF
--- a/http/openapi.go
+++ b/http/openapi.go
@@ -41,7 +41,7 @@ func FilterOutDebugMethods(openAPIFileContent string) (string, error) {
 		for method, operation := range pathItem.Operations() {
 			debugTagFound := false
 			for _, tag := range operation.Tags {
-				if strings.ToLower(strings.TrimSpace(tag)) == "debug" {
+				if strings.EqualFold(strings.TrimSpace(tag), "debug") {
 					debugTagFound = true
 					break
 				}


### PR DESCRIPTION
# Description

I just found a little nice function `strings.EqualFold`, let's train to use it where appropriate.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
