### PR TITLE
Use `io.ReadAll` instead of `ioutil.ReadAll`

### DIFF
--- a/http/openapi.go
+++ b/http/openapi.go
@@ -18,7 +18,7 @@ package httputils
 // https://redhatinsights.github.io/insights-operator-utils/packages/http/openapi.html
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -76,7 +76,7 @@ func CreateOpenAPIHandler(filePath string, debug, cacheFile bool) func(writer ht
 		if !cacheFile || len(fileContent) == 0 {
 			var err error
 			// it's not supposed that we'll accept the path from a user
-			fileContent, err = ioutil.ReadFile(filePath) // #nosec G304  (CWE-22): Potential file inclusion via variable
+			fileContent, err = io.ReadFile(filePath) // #nosec G304  (CWE-22): Potential file inclusion via variable
 			if err != nil {
 				log.Error().Err(err).Msg("error reading openapi.json file")
 				types.HandleServerError(writer, err)

--- a/http/router_utils_test.go
+++ b/http/router_utils_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -437,7 +436,7 @@ func testReadParamError(t *testing.T, paramName string, args map[string]string, 
 	resp := recorder.Result()
 	assert.NotNil(t, resp)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, expectedError, strings.TrimSpace(string(body)))

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2019, 2020 Red Hat, Inc.
+Copyright © 2019, 2020, 2021, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/RedHatInsights/insights-operator-utils/responses"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -146,7 +146,7 @@ func checkResponse(
 			t.Errorf("Unexpected content type. Expected %v, got %v", appJSON, contentType)
 		}
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/s3/downloader.go
+++ b/s3/downloader.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Red Hat, Inc
+// Copyright 2021, 2022 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ package s3util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -37,7 +37,7 @@ func DownloadObject(client s3iface.S3API, bucket, src string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := ioutil.ReadAll(result.Body)
+	b, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", CannotReadError, err.Error())
 	}

--- a/tests/helpers/catchoutput.go
+++ b/tests/helpers/catchoutput.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Red Hat, Inc
+// Copyright 2021, 2022 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package helpers
 // https://redhatinsights.github.io/insights-operator-utils/packages/tests/helpers/catchoutput.html
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -48,10 +48,10 @@ func CatchingOutputs(t *testing.T, f func()) (string, string) {
 	err = fakeStderr.Close()
 	FailOnError(t, err)
 
-	stdoutOutput, err := ioutil.ReadAll(stdoutReader)
+	stdoutOutput, err := io.ReadAll(stdoutReader)
 	FailOnError(t, err)
 
-	stderrOutput, err := ioutil.ReadAll(stderrReader)
+	stderrOutput, err := io.ReadAll(stderrReader)
 	FailOnError(t, err)
 
 	return string(stdoutOutput), string(stderrOutput)

--- a/tests/helpers/frisby.go
+++ b/tests/helpers/frisby.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Red Hat, Inc.
+Copyright © 2020, 2021, 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/verdverm/frisby"
@@ -74,7 +73,7 @@ func FrisbyExpectItemInArray(fieldName string, expectedItem interface{}) frisby.
 }
 
 func unmarshalResponseBodyToJSON(respBody io.ReadCloser, obj interface{}) error {
-	bodyBytes, err := ioutil.ReadAll(respBody)
+	bodyBytes, err := io.ReadAll(respBody)
 	if err != nil {
 		return err
 	}

--- a/tests/helpers/helpers_test.go
+++ b/tests/helpers/helpers_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -320,7 +319,7 @@ func TestGockExpectAPIRequest(t *testing.T) {
 	resp, err := http.Post(serverAddress+"/"+testEndpoint, "application/json", strings.NewReader(okBody))
 	helpers.FailOnError(t, err)
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	helpers.FailOnError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -125,7 +124,7 @@ func toBytes(t testing.TB, obj interface{}) []byte {
 	case string:
 		return []byte(v)
 	case io.Reader:
-		res, err := ioutil.ReadAll(v)
+		res, err := io.ReadAll(v)
 		FailOnError(t, err)
 		return res
 	default:
@@ -196,7 +195,7 @@ func makeRequest(t testing.TB, request *APIRequest, url string) *http.Request {
 // (ignores whitespaces, newlines, etc)
 // also validates both expected and body to be a valid json
 func CheckResponseBodyJSON(t testing.TB, expectedJSON string, body io.ReadCloser) {
-	result, err := ioutil.ReadAll(body)
+	result, err := io.ReadAll(body)
 	FailOnError(t, err)
 
 	AssertStringsAreEqualJSON(t, expectedJSON, string(result))
@@ -353,7 +352,7 @@ func CleanAfterGock(t testing.TB) {
 		t.Errorf("\tHeader: `%+v`\n", ToJSONString(request.Header))
 
 		if request.Body != nil {
-			bodyBytes, err := ioutil.ReadAll(request.Body)
+			bodyBytes, err := io.ReadAll(request.Body)
 			FailOnError(t, err)
 
 			t.Errorf("\tBody: `%+v`\n", string(bodyBytes))

--- a/tests/helpers/serialization.go
+++ b/tests/helpers/serialization.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021, 2022 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package helpers
 import (
 	"bytes"
 	"encoding/gob"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -31,7 +31,7 @@ func MustGobSerialize(t testing.TB, obj interface{}) []byte {
 	err := gob.NewEncoder(buf).Encode(obj)
 	FailOnError(t, err)
 
-	res, err := ioutil.ReadAll(buf)
+	res, err := io.ReadAll(buf)
 	FailOnError(t, err)
 
 	return res

--- a/tls/tls_config.go
+++ b/tls/tls_config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Red Hat, Inc
+// Copyright 2021, 2022 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 )
 
@@ -54,7 +54,7 @@ func newTLSConfig(t tlsConfigGetter, certPath string) (*tls.Config, error) {
 	}
 
 	// Load CA cert
-	caCert, err := ioutil.ReadFile(filepath.Clean(certPath))
+	caCert, err := io.ReadFile(filepath.Clean(certPath))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Use `io.ReadAll` instead of `ioutil.ReadAll`

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
