### PR TITLE
added new test util function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.3
-	github.com/RedHatInsights/insights-results-types v1.3.5
+	github.com/RedHatInsights/insights-results-types v1.3.12
 	github.com/RedHatInsights/kafka-zerolog v1.0.0
 	github.com/Shopify/sarama v1.27.1
 	github.com/archdx/zerolog-sentry v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHN
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.5 h1:Q1awNYeJqIFgst7zQgKfQwbdMieyJTG/eDIau+yIUpo=
 github.com/RedHatInsights/insights-results-types v1.3.5/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.12 h1:habg9ZFdX+7VH4F8ilxRLHLQjMEPJChQ1dBwLjkFS8Q=
+github.com/RedHatInsights/insights-results-types v1.3.12/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/RedHatInsights/kafka-zerolog v1.0.0 h1:4zPrLcwnfFl07qv9/ximlm1E/rWs93TkYnHrgNiU73A=
 github.com/RedHatInsights/kafka-zerolog v1.0.0/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -28,7 +28,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	types "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
@@ -371,19 +370,4 @@ func MakeXRHTokenString(t testing.TB, token *types.Token) string {
 	FailOnError(t, err)
 
 	return base64.StdEncoding.EncodeToString(tokenBytes)
-}
-
-// CompareReportResponses compares two RuleOnReport struct field by
-// field, except for the CreatedAt field that is compared with
-// time.Now() (the default when creating a new rule)
-func CompareReportResponses(expected, actual types.RuleOnReport) bool {
-
-	return actual.Disabled == expected.Disabled &&
-		actual.DisableFeedback == expected.DisableFeedback &&
-		actual.DisabledAt == expected.DisabledAt &&
-		actual.ErrorKey == expected.ErrorKey &&
-		actual.Module == expected.Module &&
-		ToJSONString(actual.TemplateData) == ToJSONString(expected.TemplateData) &&
-		actual.UserVote == expected.UserVote &&
-		actual.CreatedAt == types.Timestamp(time.Now().UTC().Format(time.RFC3339))
 }

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -28,6 +28,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	types "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
@@ -370,4 +371,19 @@ func MakeXRHTokenString(t testing.TB, token *types.Token) string {
 	FailOnError(t, err)
 
 	return base64.StdEncoding.EncodeToString(tokenBytes)
+}
+
+// CompareReportResponses compares two RuleOnReport struct field by
+// field, except for the CreatedAt field that is compared with
+// time.Now() (the default when creating a new rule)
+func CompareReportResponses(expected, actual types.RuleOnReport) bool {
+
+	return actual.Disabled == expected.Disabled &&
+		actual.DisableFeedback == expected.DisableFeedback &&
+		actual.DisabledAt == expected.DisabledAt &&
+		actual.ErrorKey == expected.ErrorKey &&
+		actual.Module == expected.Module &&
+		ToJSONString(actual.TemplateData) == ToJSONString(expected.TemplateData) &&
+		actual.UserVote == expected.UserVote &&
+		actual.CreatedAt == types.Timestamp(time.Now().UTC().Format(time.RFC3339))
 }

--- a/tests/helpers/micro_server.go
+++ b/tests/helpers/micro_server.go
@@ -19,6 +19,7 @@ package helpers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -35,7 +36,11 @@ type MicroHTTPServer struct {
 // NewMicroHTTPServer creates a MicroHTTPServer for the given address and prefix
 func NewMicroHTTPServer(address, apiPrefix string) *MicroHTTPServer {
 	router := mux.NewRouter().StrictSlash(true)
-	server := &http.Server{Addr: address, Handler: router}
+	server := &http.Server{
+		Addr:              address,
+		Handler:           router,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
 	return &MicroHTTPServer{
 		APIPrefix: apiPrefix,
 		Router:    router,

--- a/tests/helpers/rules.go
+++ b/tests/helpers/rules.go
@@ -1,0 +1,61 @@
+// Copyright 2020, 2021, 2022 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+// Documentation in literate-programming-style is available at:
+// https://redhatinsights.github.io/insights-operator-utils/packages/tests/helpers/http.html
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	types "github.com/RedHatInsights/insights-results-types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// CompareReportResponses compares two RuleOnReport struct field by
+// field, except for the CreatedAt field that is compared with
+// time.Now() (the default when creating a new rule)
+func CompareReportResponses(t testing.TB, expected, actual types.RuleOnReport) {
+	actualTemplateData := ToJSONString(actual.TemplateData)
+	expectedTemplateData := ToJSONString(expected.TemplateData)
+	require.JSONEq(t, expectedTemplateData, actualTemplateData)
+	assert.Equal(t, actual.Disabled, expected.Disabled)
+	assert.Equal(t, actual.DisableFeedback, expected.DisableFeedback)
+	assert.Equal(t, actual.DisabledAt, expected.DisabledAt)
+	assert.Equal(t, actual.ErrorKey, expected.ErrorKey)
+	assert.Equal(t, actual.Module, expected.Module)
+	assert.Equal(t, actual.UserVote, expected.UserVote)
+	assert.Equal(t, actual.CreatedAt, types.Timestamp(time.Now().UTC().Format(time.RFC3339)))
+}
+
+// SortReports sorts a list of RuleOnReport by ErrorKey field
+func SortReports(reports []types.RuleOnReport) []types.RuleOnReport {
+	errorKeyReport := make(map[string]types.RuleOnReport)
+	errorKeys := make([]string, 3)
+	sorted := make([]types.RuleOnReport, 3)
+	for _, rep := range reports {
+		errorKeyStr := string(rep.ErrorKey)
+		errorKeyReport[errorKeyStr] = rep
+		errorKeys = append(errorKeys, errorKeyStr)
+	}
+	sort.Strings(errorKeys)
+	for _, ek := range errorKeys {
+		sorted = append(sorted, errorKeyReport[ek])
+	}
+	return sorted
+}


### PR DESCRIPTION
# Description
created a new function to compare two rules responses. It is impossible to compare with a constant response as the CreatedAt field is dynamically created with time.Now() value 

Fixes CCXDEV-7859

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Testing steps
na

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
