### PR TITLE
[CCXDEV-10330] Don't send any body for 204 responses

### DIFF
--- a/responses/responses.go
+++ b/responses/responses.go
@@ -61,6 +61,10 @@ func BuildOkResponseWithData(dataName string, data interface{}) map[string]inter
 func Send(statusCode int, w http.ResponseWriter, data interface{}) error {
 	setDefaultContentType(w)
 	w.WriteHeader(statusCode)
+	if data == nil {
+		return nil
+	}
+
 	if status, ok := data.(string); ok {
 		return json.NewEncoder(w).Encode(BuildResponse(status))
 	} else if rawData, ok := data.([]byte); ok {
@@ -87,8 +91,8 @@ func SendAccepted(w http.ResponseWriter, data map[string]interface{}) error {
 }
 
 // SendNoContent returns error response with status SendNoContent 204
-func SendNoContent(w http.ResponseWriter, errorMessage string) error {
-	return Send(http.StatusNoContent, w, errorMessage)
+func SendNoContent(w http.ResponseWriter) error {
+	return Send(http.StatusNoContent, w, nil)
 }
 
 // SendBadRequest returns error response with status Bad Request 400

--- a/responses/responses_test.go
+++ b/responses/responses_test.go
@@ -22,13 +22,14 @@ package responses_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/insights-operator-utils/responses"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/RedHatInsights/insights-operator-utils/responses"
 )
 
 // Define types used in table tests struct
@@ -249,6 +250,24 @@ func TestHeaders(t *testing.T) {
 			)
 		})
 	}
+
+	t.Run("responses.SendNoContent", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := responses.SendNoContent(w) // call the function without any payload
+			if err != nil {
+				t.Fatal(err)
+			}
+		}))
+		defer testServer.Close()
+
+		checkResponse(
+			testServer.URL,
+			http.StatusNoContent,
+			false,
+			"",
+			t,
+		)
+	})
 
 	for _, test := range sendTests {
 		t.Run(test.testName, func(t *testing.T) {


### PR DESCRIPTION
# Description

204 responses doesn't allow to send any data in the body.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
