### PR TITLE
[CCXDEV-12328] Support for multiple Kafka broker addresses

### DIFF
--- a/clowder/export_test.go
+++ b/clowder/export_test.go
@@ -15,6 +15,7 @@
 package clowder
 
 var (
-	NoBrokerCfg = noBrokerConfig
-	NoSaslCfg   = noSaslConfig
+	NoBrokerCfg      = noBrokerConfig
+	NoOriginalBroker = noOriginalBroker
+	NoSaslCfg        = noSaslConfig
 )

--- a/clowder/kafka.go
+++ b/clowder/kafka.go
@@ -16,28 +16,52 @@ package clowder
 
 import (
 	"fmt"
+
 	"github.com/RedHatInsights/insights-operator-utils/kafka"
 	api "github.com/redhatinsights/app-common-go/pkg/api/v1"
 )
 
 // Common constants used for logging and error reporting
 const (
-	noBrokerConfig = "warning: no broker configurations found in clowder config"
-	noSaslConfig   = "warning: SASL configuration is missing"
-	noTopicMapping = "warning: no kafka mapping found for topic %s"
+	noOriginalBroker = "warning: no original broker configuration found; aborting"
+	noBrokerConfig   = "warning: no broker configurations found in clowder config"
+	noSaslConfig     = "warning: SASL configuration is missing"
+	noTopicMapping   = "warning: no kafka mapping found for topic %s"
 )
 
 // UseBrokerConfig tries to replace parts of the BrokerConfiguration with the values
-// loaded by Clowder
-func UseBrokerConfig(brokerCfg *kafka.MultiBrokerConfiguration, loadedConfig *api.AppConfig) {
+// loaded by Clowder. It expects brokerCfg to already be initialized
+func UseBrokerConfig(brokerCfg kafka.BrokersConfig, loadedConfig *api.AppConfig) kafka.BrokersConfig {
+	numBrokerConfigs := len(brokerCfg)
+	if numBrokerConfigs == 0 {
+		// if original brokers config is totally empty, do nothing.
+		// this shouldn't happen, but we need to control this scenario
+		// to avoid panics.
+		fmt.Println(noOriginalBroker)
+		return brokerCfg
+	}
 	if loadedConfig.Kafka != nil && len(loadedConfig.Kafka.Brokers) > 0 {
-		brokerCfg.Addresses = make([]string, len(loadedConfig.Kafka.Brokers))
-		brokerCfg.SASLConfigs = make([]kafka.SASLConfiguration, len(loadedConfig.Kafka.Brokers))
+		numClowderBrokers := len(loadedConfig.Kafka.Brokers)
+		// if original config has fewer brokers than clowder's, we append additional
+		// brokerConfiguration items with topic, clientId, and group from existing
+		// items, and the rest will be filled with data from clowder's brokers.
+		// When appending, it's most probable that a new slice is returned due to
+		// original capacity not being enough, which is why the brokerCfg slice is
+		// returned
+		for len(brokerCfg) < numClowderBrokers {
+			brokerCfg = append(brokerCfg, &kafka.BrokerConfiguration{
+				Topic:    (brokerCfg)[numBrokerConfigs-1].Topic,
+				ClientID: (brokerCfg)[numBrokerConfigs-1].ClientID,
+				Group:    (brokerCfg)[numBrokerConfigs-1].Group,
+				// Since this will have data from Clowder's loadedConfig, always enable
+				Enabled: true,
+			})
+		}
 		for i, broker := range loadedConfig.Kafka.Brokers {
 			if broker.Port != nil {
-				brokerCfg.Addresses[i] = fmt.Sprintf("%s:%d", broker.Hostname, *broker.Port)
+				(brokerCfg)[i].Address = fmt.Sprintf("%s:%d", broker.Hostname, *broker.Port)
 			} else {
-				brokerCfg.Addresses[i] = broker.Hostname
+				(brokerCfg)[i].Address = broker.Hostname
 			}
 			// SSL config
 			if broker.Authtype != nil {
@@ -45,13 +69,13 @@ func UseBrokerConfig(brokerCfg *kafka.MultiBrokerConfiguration, loadedConfig *ap
 				if broker.Sasl != nil {
 					// we are trusting that these values are set and
 					// dereferencing the pointers without any check...
-					brokerCfg.SASLConfigs[i].SaslUsername = *broker.Sasl.Username
-					brokerCfg.SASLConfigs[i].SaslPassword = *broker.Sasl.Password
-					brokerCfg.SASLConfigs[i].SaslMechanism = *broker.Sasl.SaslMechanism
-					brokerCfg.SASLConfigs[i].SecurityProtocol = *broker.SecurityProtocol
+					brokerCfg[i].SaslUsername = *broker.Sasl.Username
+					brokerCfg[i].SaslPassword = *broker.Sasl.Password
+					brokerCfg[i].SaslMechanism = *broker.Sasl.SaslMechanism
+					brokerCfg[i].SecurityProtocol = *broker.SecurityProtocol
 
 					if caPath, err := loadedConfig.KafkaCa(broker); err == nil {
-						brokerCfg.SASLConfigs[i].CertPath = caPath
+						brokerCfg[i].CertPath = caPath
 					}
 				} else {
 					fmt.Println(noSaslConfig)
@@ -61,25 +85,17 @@ func UseBrokerConfig(brokerCfg *kafka.MultiBrokerConfiguration, loadedConfig *ap
 	} else {
 		fmt.Println(noBrokerConfig)
 	}
+	return brokerCfg
 }
 
-// UseClowderTopics tries to replace the configured topic with the corresponding
-// topic loaded by Clowder
-func UseClowderTopics(brokerCfg interface{}, kafkaTopics map[string]api.TopicConfig) {
-	switch cfg := brokerCfg.(type) {
-	case *kafka.SingleBrokerConfiguration:
+// UseClowderTopics tries to replace the configured topic's name with the
+// corresponding topic name loaded by Clowder, if any
+func UseClowderTopics(brokersCfg kafka.BrokersConfig, kafkaTopics map[string]api.TopicConfig) {
+	for _, cfg := range brokersCfg {
 		if clowderTopic, ok := kafkaTopics[cfg.Topic]; ok {
 			cfg.Topic = clowderTopic.Name
 		} else {
 			fmt.Printf(noTopicMapping, cfg.Topic)
 		}
-	case *kafka.MultiBrokerConfiguration:
-		if clowderTopic, ok := kafkaTopics[cfg.Topic]; ok {
-			cfg.Topic = clowderTopic.Name
-		} else {
-			fmt.Printf(noTopicMapping, cfg.Topic)
-		}
-	default:
-		fmt.Printf("Unknown Broker configuration type")
 	}
 }

--- a/kafka/configuration.go
+++ b/kafka/configuration.go
@@ -29,8 +29,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// BrokerConfiguration represents configuration of Kafka broker
-type BrokerConfiguration struct {
+// SASLConfiguration represents configuration of SASL authentication for
+// a given Kafka broker
+type SASLConfiguration struct {
+	SecurityProtocol string `mapstructure:"security_protocol" toml:"security_protocol"`
+	CertPath         string `mapstructure:"cert_path" toml:"cert_path"`
+	SaslMechanism    string `mapstructure:"sasl_mechanism" toml:"sasl_mechanism"`
+	SaslUsername     string `mapstructure:"sasl_username" toml:"sasl_username"`
+	SaslPassword     string `mapstructure:"sasl_password" toml:"sasl_password"`
+}
+
+// SingleBrokerConfiguration represents configuration of a single-instance Kafka broker
+type SingleBrokerConfiguration struct {
 	Address          string        `mapstructure:"address" toml:"address"`
 	SecurityProtocol string        `mapstructure:"security_protocol" toml:"security_protocol"`
 	CertPath         string        `mapstructure:"cert_path" toml:"cert_path"`
@@ -44,8 +54,21 @@ type BrokerConfiguration struct {
 	Enabled          bool          `mapstructure:"enabled" toml:"enabled"`
 }
 
+// MultiBrokerConfiguration represents configuration of Kafka broker with
+// multiple instances running on different hosts
+type MultiBrokerConfiguration struct {
+	Addresses        []string            `mapstructure:"addresses" toml:"addresses"`
+	SecurityProtocol string              `mapstructure:"security_protocol" toml:"security_protocol"`
+	SASLConfigs      []SASLConfiguration `mapstructure:"sasl_configs" toml:"sasl_configs"`
+	Topic            string              `mapstructure:"topic" toml:"topic"`
+	Timeout          time.Duration       `mapstructure:"timeout" toml:"timeout"`
+	Group            string              `mapstructure:"group" toml:"group"`
+	ClientID         string              `mapstructure:"client_id" toml:"client_id"`
+	Enabled          bool                `mapstructure:"enabled" toml:"enabled"`
+}
+
 // SaramaConfigFromBrokerConfig returns a Config struct from broker.Configuration parameters
-func SaramaConfigFromBrokerConfig(cfg *BrokerConfiguration) (*sarama.Config, error) {
+func SaramaConfigFromBrokerConfig(cfg *SingleBrokerConfiguration) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V0_10_2_0
 

--- a/kafka/configuration.go
+++ b/kafka/configuration.go
@@ -39,8 +39,8 @@ type SASLConfiguration struct {
 	SaslPassword     string `mapstructure:"sasl_password" toml:"sasl_password"`
 }
 
-// SingleBrokerConfiguration represents configuration of a single-instance Kafka broker
-type SingleBrokerConfiguration struct {
+// BrokerConfiguration represents configuration of a single-instance Kafka broker
+type BrokerConfiguration struct {
 	Address          string        `mapstructure:"address" toml:"address"`
 	SecurityProtocol string        `mapstructure:"security_protocol" toml:"security_protocol"`
 	CertPath         string        `mapstructure:"cert_path" toml:"cert_path"`
@@ -54,21 +54,21 @@ type SingleBrokerConfiguration struct {
 	Enabled          bool          `mapstructure:"enabled" toml:"enabled"`
 }
 
-// MultiBrokerConfiguration represents configuration of Kafka broker with
-// multiple instances running on different hosts
-type MultiBrokerConfiguration struct {
-	Addresses        []string            `mapstructure:"addresses" toml:"addresses"`
-	SecurityProtocol string              `mapstructure:"security_protocol" toml:"security_protocol"`
-	SASLConfigs      []SASLConfiguration `mapstructure:"sasl_configs" toml:"sasl_configs"`
-	Topic            string              `mapstructure:"topic" toml:"topic"`
-	Timeout          time.Duration       `mapstructure:"timeout" toml:"timeout"`
-	Group            string              `mapstructure:"group" toml:"group"`
-	ClientID         string              `mapstructure:"client_id" toml:"client_id"`
-	Enabled          bool                `mapstructure:"enabled" toml:"enabled"`
+// BrokersConfig represents configuration of Kafka broker with
+// multiple instances running on different hosts (kafka cluster)
+type BrokersConfig []*BrokerConfiguration
+
+// GetBrokersAddresses returns array of addresses of the configured brokers
+func GetBrokersAddresses(brokersCfg BrokersConfig) []string {
+	addresses := make([]string, len(brokersCfg))
+	for i, cfg := range brokersCfg {
+		addresses[i] = cfg.Address
+	}
+	return addresses
 }
 
 // SaramaConfigFromBrokerConfig returns a Config struct from broker.Configuration parameters
-func SaramaConfigFromBrokerConfig(cfg *SingleBrokerConfiguration) (*sarama.Config, error) {
+func SaramaConfigFromBrokerConfig(cfg *BrokerConfiguration) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V0_10_2_0
 

--- a/kafka/configuration_test.go
+++ b/kafka/configuration_test.go
@@ -15,22 +15,23 @@
 package kafka_test
 
 import (
-	"github.com/RedHatInsights/insights-operator-utils/kafka"
-	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"testing"
 	"time"
+
+	"github.com/RedHatInsights/insights-operator-utils/kafka"
+	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSaramaConfigFromBrokerConfig(t *testing.T) {
-	cfg := kafka.SingleBrokerConfiguration{}
+	cfg := kafka.BrokerConfiguration{}
 	saramaConfig, err := kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 
-	cfg = kafka.SingleBrokerConfiguration{
+	cfg = kafka.BrokerConfiguration{
 		Timeout: time.Second,
 	}
 	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
@@ -41,7 +42,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	assert.Equal(t, time.Second, saramaConfig.Net.WriteTimeout)
 	assert.Equal(t, "sarama", saramaConfig.ClientID) // default value
 
-	cfg = kafka.SingleBrokerConfiguration{
+	cfg = kafka.BrokerConfiguration{
 		SecurityProtocol: "SSL",
 	}
 
@@ -50,7 +51,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.True(t, saramaConfig.Net.TLS.Enable)
 
-	cfg = kafka.SingleBrokerConfiguration{
+	cfg = kafka.BrokerConfiguration{
 		SecurityProtocol: "SASL_SSL",
 		SaslMechanism:    "PLAIN",
 		SaslUsername:     "username",
@@ -80,7 +81,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 }
 
 func TestBadConfiguration(t *testing.T) {
-	cfg := kafka.SingleBrokerConfiguration{
+	cfg := kafka.BrokerConfiguration{
 		SecurityProtocol: "SSL",
 		CertPath:         "missing_path",
 	}

--- a/kafka/configuration_test.go
+++ b/kafka/configuration_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 func TestSaramaConfigFromBrokerConfig(t *testing.T) {
-	cfg := kafka.BrokerConfiguration{}
+	cfg := kafka.SingleBrokerConfiguration{}
 	saramaConfig, err := kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 
-	cfg = kafka.BrokerConfiguration{
+	cfg = kafka.SingleBrokerConfiguration{
 		Timeout: time.Second,
 	}
 	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
@@ -41,7 +41,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	assert.Equal(t, time.Second, saramaConfig.Net.WriteTimeout)
 	assert.Equal(t, "sarama", saramaConfig.ClientID) // default value
 
-	cfg = kafka.BrokerConfiguration{
+	cfg = kafka.SingleBrokerConfiguration{
 		SecurityProtocol: "SSL",
 	}
 
@@ -50,7 +50,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.True(t, saramaConfig.Net.TLS.Enable)
 
-	cfg = kafka.BrokerConfiguration{
+	cfg = kafka.SingleBrokerConfiguration{
 		SecurityProtocol: "SASL_SSL",
 		SaslMechanism:    "PLAIN",
 		SaslUsername:     "username",
@@ -80,7 +80,7 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 }
 
 func TestBadConfiguration(t *testing.T) {
-	cfg := kafka.BrokerConfiguration{
+	cfg := kafka.SingleBrokerConfiguration{
 		SecurityProtocol: "SSL",
 		CertPath:         "missing_path",
 	}


### PR DESCRIPTION
# Description

- Support slice of BrokerConfiguration items so we can get the full KafkaBrokers config from clowder
- Differentiate kafka.BrokerConfig into BrokerConfigurations and BrokersConfig. This helps simplify and clarify what is used in which method, and will imply a slightly more complex refactor on the services' side.

Fixes CCXDEV-12328

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

- Updated UTs
- All the changes have been tested using the ccx-notification-writer with this version of ioutils (adapted the service's code and its UTs, and tried it locally)

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
