### PR TITLE
Expect adresses instead of address in toml config file

### DIFF
--- a/kafka/configuration.go
+++ b/kafka/configuration.go
@@ -31,7 +31,7 @@ import (
 
 // BrokerConfiguration represents configuration of a single-instance Kafka broker
 type BrokerConfiguration struct {
-	Addresses        []string      `mapstructure:"address" toml:"address"`
+	Addresses        []string      `mapstructure:"addresses" toml:"addresses"`
 	SecurityProtocol string        `mapstructure:"security_protocol" toml:"security_protocol"`
 	CertPath         string        `mapstructure:"cert_path" toml:"cert_path"`
 	SaslMechanism    string        `mapstructure:"sasl_mechanism" toml:"sasl_mechanism"`


### PR DESCRIPTION
# Description

Use `addresses` instead of `address` in `BrokerConfiguration, as the field is expected to be an array of strings.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

N/A

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
