### PR TITLE
Do not set a fixed Kafka version in sarama config

### DIFF
--- a/kafka/configuration.go
+++ b/kafka/configuration.go
@@ -47,7 +47,6 @@ type BrokerConfiguration struct {
 // SaramaConfigFromBrokerConfig returns a Config struct from broker.Configuration parameters
 func SaramaConfigFromBrokerConfig(cfg *BrokerConfiguration) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
-	saramaConfig.Version = sarama.V0_10_2_0
 
 	if cfg.Timeout > 0 {
 		saramaConfig.Net.DialTimeout = cfg.Timeout

--- a/kafka/configuration_test.go
+++ b/kafka/configuration_test.go
@@ -27,16 +27,14 @@ import (
 
 func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	cfg := kafka.BrokerConfiguration{}
-	saramaConfig, err := kafka.SaramaConfigFromBrokerConfig(&cfg)
+	_, err := kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 
 	cfg = kafka.BrokerConfiguration{
 		Timeout: time.Second,
 	}
-	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
+	saramaConfig, err := kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.Equal(t, time.Second, saramaConfig.Net.DialTimeout)
 	assert.Equal(t, time.Second, saramaConfig.Net.ReadTimeout)
 	assert.Equal(t, time.Second, saramaConfig.Net.WriteTimeout)
@@ -48,7 +46,6 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 
 	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.True(t, saramaConfig.Net.TLS.Enable)
 
 	cfg = kafka.BrokerConfiguration{
@@ -60,7 +57,6 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	}
 	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.True(t, saramaConfig.Net.TLS.Enable)
 	assert.True(t, saramaConfig.Net.SASL.Enable)
 	assert.Equal(t, sarama.SASLMechanism("PLAIN"), saramaConfig.Net.SASL.Mechanism)
@@ -71,7 +67,6 @@ func TestSaramaConfigFromBrokerConfig(t *testing.T) {
 	cfg.SaslMechanism = "SCRAM-SHA-512"
 	saramaConfig, err = kafka.SaramaConfigFromBrokerConfig(&cfg)
 	helpers.FailOnError(t, err)
-	assert.Equal(t, sarama.V0_10_2_0, saramaConfig.Version)
 	assert.True(t, saramaConfig.Net.TLS.Enable)
 	assert.True(t, saramaConfig.Net.SASL.Enable)
 	assert.Equal(t, sarama.SASLMechanism(sarama.SASLTypeSCRAMSHA512), saramaConfig.Net.SASL.Mechanism)


### PR DESCRIPTION
# Description

From Sarama documentation:
`The version field represents the version of Kafka that Sarama will assume it is running against. It defaults to the oldest supported stable version. Since Kafka provides backwards-compatibility, setting it to a version older than you have will not break anything, although it may prevent you from using the latest features. Setting it to a version greater than you are actually running may lead to random breakage.
`

Let's not hardcode it to a specific version

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UT in ccx-notification-service that creates a producer was not passing due to this line, as the `Sarama.mockBroker` is not working properly with a list of addresses and this version. Now it does

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
