### PR TITLE
[CCXDEV-14053] Don't use ERROR level for all kind of HTTP error responses

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -30,6 +30,7 @@ import (
 
 // responseDataError is used as the error message when the responses functions return an error
 const responseDataError = "Unexpected error during response data encoding"
+const handleServerErrorStr = "handleServerError()"
 
 // RouterMissingParamError missing parameter in request
 type RouterMissingParamError struct {
@@ -107,7 +108,7 @@ func (e *ValidationError) Error() string {
 
 // HandleServerError handles separate server errors and sends appropriate responses
 func HandleServerError(writer http.ResponseWriter, err error) {
-	log.Error().Err(err).Msg("handleServerError()")
+	log.Warn().Err(err).Msg(handleServerErrorStr)
 
 	var respErr error
 
@@ -123,6 +124,7 @@ func HandleServerError(writer http.ResponseWriter, err error) {
 	case *ForbiddenError:
 		respErr = responses.SendForbidden(writer, err.Error())
 	default:
+		log.Error().Err(err).Msg(handleServerErrorStr)
 		respErr = responses.SendInternalServerError(writer, "Internal Server Error")
 	}
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -108,7 +108,7 @@ func (e *ValidationError) Error() string {
 
 // HandleServerError handles separate server errors and sends appropriate responses
 func HandleServerError(writer http.ResponseWriter, err error) {
-	log.Warn().Err(err).Msg(handleServerErrorStr)
+	var level = log.Warn() // set the default log level for most HTTP responses
 
 	var respErr error
 
@@ -124,9 +124,11 @@ func HandleServerError(writer http.ResponseWriter, err error) {
 	case *ForbiddenError:
 		respErr = responses.SendForbidden(writer, err.Error())
 	default:
-		log.Error().Err(err).Msg(handleServerErrorStr)
+		level = log.Error()
 		respErr = responses.SendInternalServerError(writer, "Internal Server Error")
 	}
+
+	level.Err(err).Msg(handleServerErrorStr)
 
 	if respErr != nil {
 		log.Error().Err(respErr).Msg(responseDataError)


### PR DESCRIPTION
# Description

Don't use `ERROR` level for all kind of HTTP error responses because it's overloading our Glitchtip instance causing plenty of duplicates. Let's use `WARN` instead, unless for unknown errors.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
