### PR TITLE
[CCXDEV-14052][CCXDEV-14098] Avoid duplicates when using Sentry/Glitchtip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/archdx/zerolog-sentry v1.8.4
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/getkin/kin-openapi v0.22.1
+	github.com/getsentry/sentry-go v0.24.1
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.5.0
@@ -42,7 +43,6 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/frankban/quicktest v1.14.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/getsentry/sentry-go v0.24.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -36,7 +36,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/getsentry/sentry-go"
+	sentry "github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -223,7 +223,7 @@ func setupCloudwatchLogging(conf *CloudWatchConfiguration) (io.Writer, error) {
 	return cloudWatchWriter, nil
 }
 
-func sentryBeforeSend(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+func sentryBeforeSend(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 	event.Fingerprint = []string{event.Message}
 	return event
 }


### PR DESCRIPTION
# Description

It looks like Sentry groups the errors following [this order](https://medium.com/@aleksandr.chistiakov/sentry-make-it-work-not-just-noisy-ebbfa9c40850):

- Stacktrace
- Exception
- Message

Even though we tried to make a lot of changes to the `log.Error()` logs using `Err` and avoiding `Msgf`, we still have duplicates. This is because the Stacktrace/Exception are still dynamic, so we need to make use of [custom fingerprints](https://docs.sentry.io/platforms/go/usage/sdk-fingerprinting/) to better group our errors.

We can tweak this function in the future in order to apply some more filtering on the events, like f.e grouping by just the first 10 characters of the error message.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
