### PR TITLE
Add utility to convert from uint64 to uint32 securely

### DIFF
--- a/goerrcheck.sh
+++ b/goerrcheck.sh
@@ -25,7 +25,7 @@ echo -e "${BLUE}Finding all unchecked errors${NC}"
 if ! [ -x "$(command -v errcheck)" ]
 then
     echo -e "${BLUE}Installing errcheck ${NC}"
-    GO111MODULE=off go get github.com/kisielk/errcheck
+    GO111MODULE=on go install github.com/kisielk/errcheck@latest
 fi
 
 

--- a/ineffassign.sh
+++ b/ineffassign.sh
@@ -24,7 +24,7 @@ echo -e "${BLUE}Detecting ineffectual assignments in Go code${NC}"
 if ! [ -x "$(command -v ineffassign)" ]
 then
     echo -e "${BLUE}Installing ineffassign${NC}"
-    GO111MODULE=off go get github.com/gordonklaus/ineffassign
+    GO111MODULE=on go install github.com/gordonklaus/ineffassign@latest
 fi
 
 if ! ineffassign ./...

--- a/migrations/errors.go
+++ b/migrations/errors.go
@@ -177,7 +177,7 @@ func regexGetNthMatch(regexStr string, nMatch uint, str string) (string, error) 
 	}
 
 	matches := regex.FindStringSubmatch(str)
-	if len(matches) < int(nMatch+1) {
+	if uint(len(matches)) < nMatch+1 {
 		return "", errors.New("regexGetNthMatch unable to find match")
 	}
 

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"errors"
+)
+
+// Uint64ToUint32 safely converts a uint64 into a uint32 without overflow
+func Uint64ToUint32(v uint64) (uint32, error) {
+	// Check for overflow without casting
+	if v > uint64(^uint32(0)) { // ^uint32(0) is the maximum uint32 value (4,294,967,295)
+		return 0, errors.New("value exceeds uint32 range")
+	}
+
+	return uint32(v), nil // #nosec G103: safe after bounds check
+}

--- a/types/conversion_test.go
+++ b/types/conversion_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package types
+
+import (
+	"testing"
+)
+
+func TestUint64ToUint32(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   uint64
+		want    uint32
+		wantErr bool
+	}{
+		{"Zero", 0, 0, false},
+		{"Max uint32", 4294967295, 4294967295, false},
+		{"Overflow", 4294967296, 0, true},
+		{"Large overflow", 18446744073709551615, 0, true},
+		{"Mid-range value", 2147483648, 2147483648, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Uint64ToUint32(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Uint64ToUint32() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Uint64ToUint32() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

- Added a utility function for secure conversion between uint types.
- Make Go linters happier (not refactoring further as I don't know if there are any tests checking the status of the returned errors during parsing)

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
