### PR TITLE
[CCXDEV-14922] Add username arg to CreateRedisClient function

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   gotests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   golint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Shell check

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -39,6 +39,7 @@ type Client struct {
 func CreateRedisClient(
 	address string,
 	databaseIndex int,
+	username string,
 	password string,
 	timeoutSeconds int,
 ) (*redisV9.Client, error) {
@@ -62,6 +63,7 @@ func CreateRedisClient(
 	c := redisV9.NewClient(&redisV9.Options{
 		Addr:        address,
 		DB:          databaseIndex,
+		Username:    username,
 		Password:    password,
 		ReadTimeout: time.Duration(timeoutSeconds) * time.Second,
 	})

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -31,6 +31,7 @@ var (
 	ctx                        context.Context
 	defaultRedisAddress        = "loclahost:6379"
 	defaultRedisDatabase       = 0
+	defaultRedisUsername       = "default"
 	defaultRedisPassword       = "psw"
 	defaultRedisTimeoutSeconds = 30
 )
@@ -58,7 +59,7 @@ func redisExpectationsMet(t *testing.T, mock redismock.ClientMock) {
 
 func TestCreateRedisClientOK(t *testing.T) {
 	client, err := redis.CreateRedisClient(
-		defaultRedisAddress, defaultRedisDatabase, defaultRedisPassword, defaultRedisTimeoutSeconds,
+		defaultRedisAddress, defaultRedisDatabase, defaultRedisUsername, defaultRedisPassword, defaultRedisTimeoutSeconds,
 	)
 	assert.NoError(t, err)
 
@@ -73,7 +74,7 @@ func TestCreateRedisClientOK(t *testing.T) {
 func TestCreateRedisClientBadAddress(t *testing.T) {
 	// empty address
 	client, err := redis.CreateRedisClient(
-		"", defaultRedisDatabase, defaultRedisPassword, defaultRedisTimeoutSeconds,
+		"", defaultRedisDatabase, defaultRedisUsername, defaultRedisPassword, defaultRedisTimeoutSeconds,
 	)
 	assert.Nil(t, client)
 	assert.Error(t, err)
@@ -82,7 +83,7 @@ func TestCreateRedisClientBadAddress(t *testing.T) {
 func TestCreateRedisClientDBIndexOutOfRange(t *testing.T) {
 	// Redis supports "only" 16 different databases with indices 0-15
 	client, err := redis.CreateRedisClient(
-		defaultRedisAddress, 16, defaultRedisPassword, defaultRedisTimeoutSeconds,
+		defaultRedisAddress, 16, defaultRedisUsername, defaultRedisPassword, defaultRedisTimeoutSeconds,
 	)
 	assert.Nil(t, client)
 	assert.Error(t, err)


### PR DESCRIPTION
# Description

Currently, the `CreateRedisClient` function does not use username for authentication to the Redis instance. However, Clowder provides username as well, so this PR adds it so we can authenticate properly.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

NA

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
