### PR TITLE
[CCXDEV-15295] Adding new Error type that show specific item type was not found in storage

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -128,7 +128,7 @@ func HandleServerError(writer http.ResponseWriter, err error) {
 		respErr = responses.SendBadRequest(writer, err.Error())
 	case *json.UnmarshalTypeError:
 		respErr = responses.SendBadRequest(writer, "bad type in json data")
-	case *ItemNotFoundError:
+	case *ItemNotFoundError, *ItemTypeNotFoundError:
 		respErr = responses.SendNotFound(writer, err.Error())
 	case *UnauthorizedError:
 		respErr = responses.SendUnauthorized(writer, err.Error())
@@ -155,7 +155,17 @@ type ItemNotFoundError struct {
 	ItemID interface{}
 }
 
+// ItemTypeNotFoundError shows that specific type of item wasn't found in storage
+type ItemTypeNotFoundError struct {
+	ItemType interface{}
+}
+
 // Error returns error string
 func (e *ItemNotFoundError) Error() string {
 	return fmt.Sprintf("Item with ID %+v was not found in the storage", e.ItemID)
+}
+
+// Error returns error string
+func (e *ItemTypeNotFoundError) Error() string {
+	return fmt.Sprintf("Item with type %+v was not found in the storage", e.ItemType)
 }

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -149,12 +149,27 @@ func TestItemNotFoundError(t *testing.T) {
 	assert.Equal(t, err.Error(), expected)
 }
 
+// TestItemTypeNotFoundError checks the method Error() for data structure
+// ItemTypeNotFoundError.
+func TestItemTypeNotFoundError(t *testing.T) {
+	// expected error value
+	const expected = "Item with type ITEM_TYPE was not found in the storage"
+
+	// construct an instance of error interface
+	err := types.ItemTypeNotFoundError{
+		ItemType: "ITEM_TYPE"}
+
+	// check if error value is correct
+	assert.Equal(t, err.Error(), expected)
+}
+
 // TestHandleServer error check the function HandleServerError defined in errors.go
 func TestHandleServerError(t *testing.T) {
 	// check the behaviour with all error types defined in this package
 	testResponse(t, &types.RouterMissingParamError{}, http.StatusBadRequest)
 	testResponse(t, &types.RouterParsingError{}, http.StatusBadRequest)
 	testResponse(t, &types.ItemNotFoundError{}, http.StatusNotFound)
+	testResponse(t, &types.ItemTypeNotFoundError{}, http.StatusNotFound)
 	testResponse(t, &types.UnauthorizedError{}, http.StatusUnauthorized)
 	testResponse(t, &types.ForbiddenError{}, http.StatusForbidden)
 	testResponse(t, &types.ForbiddenError{}, http.StatusForbidden)


### PR DESCRIPTION
# Description

Adding new Error type that show specific item type was not found in storage so we dont get separate Glitchtip issue for items with different ID's as before `ItemNotFoundError` was used which used the item id in it's message.
For example there is issue `Item with ID 34c3ecc5-624a-49a5-bab8-4fdc5e51a266 was not found in the storage` with new error all issues for specific item type will be merged in one issue based on their item type. Id will be added as additional parameter in Glitchtip `Item with type cluster was not found in the storage`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
Unit tests were added

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
