### PR TITLE
[CCXDEV-16244] Add Codecov integration with unit-tests flag

### DIFF
--- a/.github/workflows/gotests.yaml
+++ b/.github/workflows/gotests.yaml
@@ -26,3 +26,10 @@ jobs:
         run: go test -coverprofile coverage.out $(go list ./... | grep -v tests)
       - name: Display code coverage
         run: go tool cover -func=coverage.out
+      - name: Upload coverage to Codecov
+        if: matrix.go-version == '1.25'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
+          fail_ci_if_error: false


### PR DESCRIPTION
# Description

- Add `codecov/codecov-action@v5` upload step after unit test coverage generation
- Runs only for Go 1.25 to avoid duplicate uploads from the version matrix
- Uses `CODECOV_TOKEN`, `flags: unit-tests`, `fail_ci_if_error: false`

Fixes CCXDEV-16244

## Type of change

- Configuration update