### PR TITLE
fix: replace archived zerolog-sentry with sentry-go/zerolog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/IBM/sarama v1.47.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.9
 	github.com/RedHatInsights/insights-results-types v1.23.5
-	github.com/archdx/zerolog-sentry v1.8.5
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.67.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.98.0
 	github.com/getkin/kin-openapi v0.134.0
-	github.com/getsentry/sentry-go v0.44.1
+	github.com/getsentry/sentry-go v0.46.0
+	github.com/getsentry/sentry-go/zerolog v0.46.0
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9Pq
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/archdx/zerolog-sentry v0.0.1/go.mod h1:dAIUEqBAhDI/yVS3nqOr7VS9BsvHJ5btxoGFEE2RmGk=
-github.com/archdx/zerolog-sentry v1.8.5 h1:W24e5+yfZiQ83yd9OjBw+o6ERUzyUlCpoBS97gUlwK8=
-github.com/archdx/zerolog-sentry v1.8.5/go.mod h1:XrFHGe1CH5DQk/XSySu/IJSi5C9XR6+zpc97zVf/c4c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -225,8 +223,10 @@ github.com/getkin/kin-openapi v0.22.1/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s
 github.com/getkin/kin-openapi v0.134.0 h1:/L5+1+kfe6dXh8Ot/wqiTgUkjOIEJiC0bbYVziHB8rU=
 github.com/getkin/kin-openapi v0.134.0/go.mod h1:wK6ZLG/VgoETO9pcLJ/VmAtIcl/DNlMayNTb716EUxE=
 github.com/getsentry/sentry-go v0.6.1/go.mod h1:0yZBuzSvbZwBnvaF9VwZIMen3kXscY8/uasKtAX1qG8=
-github.com/getsentry/sentry-go v0.44.1 h1:/cPtrA5qB7uMRrhgSn9TYtcEF36auGP3Y6+ThvD/yaI=
-github.com/getsentry/sentry-go v0.44.1/go.mod h1:XDotiNZbgf5U8bPDUAfvcFmOnMQQceESxyKaObSssW0=
+github.com/getsentry/sentry-go v0.46.0 h1:mbdDaarbUdOt9X+dx6kDdntkShLEX3/+KyOsVDTPDj0=
+github.com/getsentry/sentry-go v0.46.0/go.mod h1:evVbw2qotNUdYG8KxXbAdjOQWWvWIwKxpjdZZIvcIPw=
+github.com/getsentry/sentry-go/zerolog v0.46.0 h1:/kXddDbSPEbjwck2DXQnSQPnei2K0DVjyN3cAbFG5lg=
+github.com/getsentry/sentry-go/zerolog v0.46.0/go.mod h1:zQ3ipnNvKBq/Grjrb6tx6RGh+TGJ1ne42z2NOU/PF8E=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -32,12 +32,12 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
-	zlogsentry "github.com/archdx/zerolog-sentry"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	sentry "github.com/getsentry/sentry-go"
+	sentryzerolog "github.com/getsentry/sentry-go/zerolog"
 	cww "github.com/lzap/cloudwatchwriter2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -245,11 +245,13 @@ func sentryBeforeSend(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 }
 
 func setupSentryLogging(conf SentryLoggingConfiguration) (io.WriteCloser, error) {
-	sentryWriter, err := zlogsentry.New(
-		conf.SentryDSN,
-		zlogsentry.WithEnvironment(conf.SentryEnvironment),
-		zlogsentry.WithBeforeSend(sentryBeforeSend),
-	)
+	sentryWriter, err := sentryzerolog.New(sentryzerolog.Config{
+		ClientOptions: sentry.ClientOptions{
+			Dsn:         conf.SentryDSN,
+			Environment: conf.SentryEnvironment,
+			BeforeSend:  sentryBeforeSend,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

`github.com/archdx/zerolog-sentry` is [archived](https://github.com/archdx/zerolog-sentry) and no longer maintained.

`sentry-go v0.46.0` (released 2026-04-21) removed the `Extra` field from `sentry.Event` as a [breaking change](https://github.com/getsentry/sentry-go/blob/v0.46.0/CHANGELOG.md#breaking-changes-), which `zerolog-sentry v1.8.5` still references — causing a compile failure across all downstream repos that depend on this library:

```
github.com/archdx/zerolog-sentry@v1.8.5/writer.go:45:20: event.Extra undefined (type *sentry.Event has no field or method Extra)
```

This breaks the following MintMaker PRs in downstream repos: insights-results-aggregator-cleaner, insights-results-aggregator, insights-results-aggregator-exporter, ccx-notification-writer, content-service, parquet-factory, insights-operator-gathering-conditions-service.

## Fix

Replace `github.com/archdx/zerolog-sentry` with the official maintained replacement: `github.com/getsentry/sentry-go/zerolog`, which is part of the sentry-go project itself and explicitly compatible with v0.46.0+. Its implementation is equivalent — the sentry-go zerolog README even notes that its implementation was based on zerolog-sentry.

The change is limited to `logger/logger.go`: swap the import and update `setupSentryLogging` to use the new `sentryzerolog.Config` struct. The `sentryBeforeSend` callback is passed directly via `sentry.ClientOptions.BeforeSend`, which is equivalent to the old `zlogsentry.WithBeforeSend`.

All existing tests pass locally (`go test ./...`).