### PR TITLE
fix: extract repeated Prometheus label and response key strings to constants

### DIFF
--- a/http/metrics_middleware.go
+++ b/http/metrics_middleware.go
@@ -29,6 +29,8 @@ import (
 	"github.com/RedHatInsights/insights-operator-utils/metrics"
 )
 
+const endpointLabel = "endpoint"
+
 type loggingResponseWriter struct {
 	http.ResponseWriter
 	endpoint string
@@ -39,7 +41,7 @@ func (writer loggingResponseWriter) WriteHeader(statusCode int) {
 	metrics.APIResponseStatusCodes.With(
 		prometheus.Labels{
 			"status_code": fmt.Sprint(statusCode),
-			"endpoint":    writer.endpoint},
+			endpointLabel:    writer.endpoint},
 	).Inc()
 }
 
@@ -53,7 +55,7 @@ func logRequestHandler(writer http.ResponseWriter, request *http.Request, nextHa
 		endpoint = ""
 	}
 
-	metrics.APIRequests.With(prometheus.Labels{"endpoint": endpoint}).Inc()
+	metrics.APIRequests.With(prometheus.Labels{endpointLabel: endpoint}).Inc()
 
 	startTime := time.Now()
 	nextHandler.ServeHTTP(&loggingResponseWriter{
@@ -63,7 +65,7 @@ func logRequestHandler(writer http.ResponseWriter, request *http.Request, nextHa
 	duration := time.Since(startTime)
 
 	metrics.APIResponsesTime.With(
-		prometheus.Labels{"endpoint": endpoint},
+		prometheus.Labels{endpointLabel: endpoint},
 	).Observe(duration.Seconds())
 }
 

--- a/http/metrics_middleware.go
+++ b/http/metrics_middleware.go
@@ -41,7 +41,7 @@ func (writer loggingResponseWriter) WriteHeader(statusCode int) {
 	metrics.APIResponseStatusCodes.With(
 		prometheus.Labels{
 			"status_code": fmt.Sprint(statusCode),
-			endpointLabel:    writer.endpoint},
+			endpointLabel: writer.endpoint},
 	).Inc()
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -32,25 +32,27 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const endpointLabel = "endpoint"
+
 var (
 	// APIRequests is a counter vector for requests to endpoints
 	APIRequests *prometheus.CounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "api_endpoints_requests",
 		Help: "The total number of requests per endpoint",
-	}, []string{"endpoint"})
+	}, []string{endpointLabel})
 
 	// APIResponsesTime collects the information about api response time per endpoint
 	APIResponsesTime *prometheus.HistogramVec = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "api_endpoints_response_time",
 		Help:    "API endpoints response time",
 		Buckets: prometheus.LinearBuckets(0, 20, 20),
-	}, []string{"endpoint"})
+	}, []string{endpointLabel})
 
 	// APIResponseStatusCodes collects the information about api response status codes
 	APIResponseStatusCodes *prometheus.CounterVec = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "api_endpoints_status_codes",
 		Help: "API endpoints status codes",
-	}, []string{"status_code", "endpoint"})
+	}, []string{"status_code", endpointLabel})
 )
 
 // AddAPIMetricsWithNamespace overwrite the defined metrics with namespaced version of them
@@ -63,18 +65,18 @@ func AddAPIMetricsWithNamespace(namespace string) {
 		Namespace: namespace,
 		Name:      "api_endpoints_requests",
 		Help:      "The total number of requests per endpoint",
-	}, []string{"endpoint"})
+	}, []string{endpointLabel})
 
 	APIResponsesTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: namespace,
 		Name:      "api_endpoints_response_time",
 		Help:      "API endpoints response time",
 		Buckets:   prometheus.LinearBuckets(0, 20, 20),
-	}, []string{"endpoint"})
+	}, []string{endpointLabel})
 
 	APIResponseStatusCodes = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "api_endpoints_status_codes",
 		Help:      "API endpoints status codes",
-	}, []string{"status_code", "endpoint"})
+	}, []string{"status_code", endpointLabel})
 }

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -28,6 +28,7 @@ import (
 const (
 	contentType = "Content-Type"
 	appJSON     = "application/json; charset=utf-8"
+	statusKey   = "status"
 )
 
 // setDefaultContentType is a helper function to set the Content-Type header
@@ -37,17 +38,17 @@ func setDefaultContentType(w http.ResponseWriter) {
 
 // BuildResponse builds response for RestAPI request
 func BuildResponse(status string) map[string]interface{} {
-	return map[string]interface{}{"status": status}
+	return map[string]interface{}{statusKey: status}
 }
 
 // BuildOkResponse builds simple "ok" response
 func BuildOkResponse() map[string]interface{} {
-	return map[string]interface{}{"status": "ok"}
+	return map[string]interface{}{statusKey: "ok"}
 }
 
 // BuildOkResponseWithData builds response with status "ok" and data
 func BuildOkResponseWithData(dataName string, data interface{}) map[string]interface{} {
-	resp := map[string]interface{}{"status": "ok"}
+	resp := map[string]interface{}{statusKey: "ok"}
 	resp[dataName] = data
 	return resp
 }
@@ -55,7 +56,7 @@ func BuildOkResponseWithData(dataName string, data interface{}) map[string]inter
 // Send sends HTTP response with a provided statusCode
 // data can be either string or map[string]interface{}
 // if data is string it will send response like this:
-// {"status": data} which is helpful for explaining error to the client
+// {statusKey: data} which is helpful for explaining error to the client
 //
 // Returned error value is based on error returned from json.Encoder
 func Send(statusCode int, w http.ResponseWriter, data interface{}) error {


### PR DESCRIPTION
## What broke and why

golangci-lint v2.12.0 flagged repeated string literals in production code across three packages:

- `metrics/metrics.go`: `"endpoint"` used 6 times as a Prometheus label name in `[]string{...}` label definitions
- `http/metrics_middleware.go`: `"endpoint"` used 3 times as a Prometheus label key in `prometheus.Labels{...}`
- `responses/responses.go`: `"status"` used 3 times as a JSON response map key

## Why this fix

Extracting to package-level constants is the correct approach for repeated production string literals:
- Prometheus label names (`endpointLabel`) are now refactor-safe — renaming the label requires changing one place
- The response key (`statusKey`) is consistent across all `BuildResponse` variants

Each package defines its own constant since they are in separate packages.

## Unblocks

Allows https://github.com/RedHatInsights/insights-operator-utils/pull/868 to pass CI and merge.